### PR TITLE
phase fieldmaps not converting

### DIFF
--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1504,6 +1504,8 @@ class NiftiWrapper(object):
         if len(data.shape) == 2:
             data = data.reshape(data.shape + (1,))
         
+        if data.dtype =='object':
+            data = data.astype(int)
         #Create the nifti image and set header data
         nii_img = nb.nifti1.Nifti1Image(data, affine)
         hdr = nii_img.get_header()


### PR DESCRIPTION
My phase fieldmaps are not converting. The error was:

  File "build/bdist.linux-x86_64/egg/dcmstack/dcmmeta.py", line 1496, in from_dicom_wrapper
    nii_img = nb.nifti1.Nifti1Image(data, affine)
  File "/srv/software/python/EPD/virtualenvs/7.2/nipype0.5/lib/python2.7/site-packages/nibabel/spatialimages.py", line 317, in **init**
    self._header.set_data_dtype(data.dtype)
  File "/srv/software/python/EPD/virtualenvs/7.2/nipype0.5/lib/python2.7/site-packages/nibabel/analyze.py", line 578, in set_data_dtype
    'data dtype "%s" not recognized' % datatype)
HeaderDataError: data dtype "object" not recognized

Not sure why only my phase fieldmap datatypes are "object" instead of "int16" so I added a couple lines to get it convert. I don't think its the best fix though, so any suggestions would be appreciated!
