### PR TITLE
Changes required to use dcmstack with Python 3

### DIFF
--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1249,8 +1249,8 @@ class NiftiWrapper(object):
             if extension.get_code() == dcm_meta_ecode:
                 try:
                     extension.check_valid()
-                except InvalidExtensionError, e:
-                    print "Found candidate extension, but invalid: %s" % e
+                except InvalidExtensionError as e:
+                    print("Found candidate extension, but invalid: %s" % e)
                 else:
                     if not self.meta_ext is None:
                         raise ValueError('More than one valid DcmMeta '

--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1,6 +1,8 @@
 """
 DcmMeta header extension and NiftiWrapper for working with extended Niftis.
 """
+from __future__ import print_function
+
 import sys
 import json, warnings
 from copy import deepcopy

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -1051,7 +1051,7 @@ def parse_and_group(src_paths, group_by=default_group_keys, extractor=None,
         #Read the DICOM file
         try:
             dcm = dicom.read_file(dcm_path, force=force)
-        except Exception, e:
+        except Exception as e:
             if warn_on_except:
                 warnings.warn('Error reading file %s: %s' % (dcm_path, str(e)))
                 continue
@@ -1113,7 +1113,7 @@ def stack_group(group, warn_on_except=False, **stack_args):
     for dcm, meta, fn in group:
         try:
             result.add_dcm(dcm, meta)
-        except Exception, e:
+        except Exception as e:
             if warn_on_except:
                 warnings.warn('Error adding file %s to stack: %s' %
                               (fn, str(e)))

--- a/src/dcmstack/dcmstack_cli.py
+++ b/src/dcmstack/dcmstack_cli.py
@@ -153,23 +153,23 @@ def main(argv=sys.argv):
     args = arg_parser.parse_args(argv[1:])
 
     if args.version:
-        print __version__
+        print(__version__)
         return 0
 
     #Check if we are just listing the translators
     if args.list_translators:
         for translator in extract.default_translators:
-            print '%s -> %s' % (translator.tag, translator.name)
+            print('%s -> %s' % (translator.tag, translator.name))
         return 0
 
     #Check if we are just listing the default exclude regular expressions
     if args.default_regexes:
-        print 'Default exclude regular expressions:'
+        print('Default exclude regular expressions:')
         for regex in dcmstack.default_key_excl_res:
-            print '\t' + regex
-        print 'Default include regular expressions:'
+            print('\t' + regex)
+        print('Default include regular expressions:')
         for regex in dcmstack.default_key_incl_res:
-            print '\t' + regex
+            print('\t' + regex)
         return 0
 
     #Check if we are generating meta data
@@ -250,10 +250,10 @@ def main(argv=sys.argv):
     #Handle each source directory individually
     for src_dir in args.src_dirs:
         if not os.path.isdir(src_dir):
-            print >> sys.stderr, '%s is not a directory, skipping' % src_dir
+            print('%s is not a directory, skipping' % src_dir, file=sys.stderr)
 
         if args.verbose:
-            print "Processing source directory %s" % src_dir
+            print("Processing source directory %s" % src_dir)
 
         #Build a list of paths to source files
         glob_str = os.path.join(src_dir, '*')
@@ -262,7 +262,7 @@ def main(argv=sys.argv):
         src_paths = glob(glob_str)
 
         if args.verbose:
-            print "Found %d source files in the directory" % len(src_paths)
+            print("Found %d source files in the directory" % len(src_paths))
 
         #Group the files in this directory
         groups = parse_and_group(src_paths,
@@ -273,10 +273,10 @@ def main(argv=sys.argv):
                                 )
 
         if args.verbose:
-            print "Found %d groups of DICOM images" % len(groups)
+            print("Found %d groups of DICOM images" % len(groups))
 
         if len(groups) == 0:
-            print "No DICOM files found in %s" % src_dir
+            print("No DICOM files found in %s" % src_dir)
 
         out_idx = 0
         generated_outs = set()
@@ -319,7 +319,7 @@ def main(argv=sys.argv):
                 out_path = os.path.join(src_dir, out_fn)
 
             if args.verbose:
-                print "Writing out stack to path %s" % out_path
+                print("Writing out stack to path %s" % out_path)
 
             nii = stack.to_nifti(args.voxel_order, gen_meta)
 

--- a/src/dcmstack/dcmstack_cli.py
+++ b/src/dcmstack/dcmstack_cli.py
@@ -3,6 +3,8 @@ Command line interface to dcmstack.
 
 @author: moloney
 """
+from __future__ import print_function
+
 import os, sys, argparse, string
 from glob import glob
 import dicom

--- a/src/dcmstack/extract.py
+++ b/src/dcmstack/extract.py
@@ -219,7 +219,7 @@ def csa_series_trans_func(elem):
     if not phx_src is None:
         phoenix_dict = parse_phoenix_prot(phx_src, csa_dict[phx_src])
         del csa_dict[phx_src]
-        for key, val in phoenix_dict.iteritems():
+        for key, val in phoenix_dict.items():
             new_key = '%s.%s' % ('MrPhoenixProtocol', key)
             csa_dict[new_key] = val
 
@@ -307,8 +307,8 @@ default_conversions = {'DS' : float,
                        'OW or OB' : get_text,
                        'OB or OW' : get_text,
                        'UN' : get_text,
-                       'PN' : unicode,
-                       'UI' : unicode,
+                       'PN' : str,
+                       'UI' : str,
                       }
 
 class MetaExtractor(object):
@@ -459,7 +459,7 @@ class MetaExtractor(object):
                     if self.warn_on_trans_except:
                         warnings.warn("Exception from translator %s: %s" %
                                       (trans_map[elem.tag].name,
-                                       repr(unicode(e))))
+                                       repr(str(e))))
                     else:
                         raise
                 else:
@@ -494,8 +494,8 @@ class MetaExtractor(object):
             result[name] = value
 
         #Inject translator results
-        for trans_name, meta in trans_meta_dicts.iteritems():
-            for name, value in meta.iteritems():
+        for trans_name, meta in trans_meta_dicts.items():
+            for name, value in meta.items():
                 name = '%s.%s' % (trans_name, name)
                 result[name] = value
 

--- a/src/dcmstack/extract.py
+++ b/src/dcmstack/extract.py
@@ -22,6 +22,9 @@ except ImportError:
 #long of a decimal string)
 dicom.config.enforce_valid_values = False
 
+# Python 2 / 3 compatibility
+unicode_str = unicode if sys.version_info[0] < 3 else str
+
 def is_ascii(in_str):
     '''Return true if the given string is valid ASCII.'''
     if all(' ' <= c <= '~' for c in in_str):
@@ -307,8 +310,8 @@ default_conversions = {'DS' : float,
                        'OW or OB' : get_text,
                        'OB or OW' : get_text,
                        'UN' : get_text,
-                       'PN' : str,
-                       'UI' : str,
+                       'PN' : unicode_str,
+                       'UI' : unicode_str,
                       }
 
 class MetaExtractor(object):

--- a/src/dcmstack/nitool_cli.py
+++ b/src/dcmstack/nitool_cli.py
@@ -3,6 +3,8 @@ Command line interface for nitool.
 
 @author: moloney
 """
+from __future__ import print_function
+
 import os, sys, argparse
 import nibabel as nb
 from .dcmmeta import NiftiWrapper, DcmMetaExtension, MissingExtensionError
@@ -109,7 +111,7 @@ def split(args):
     try:
         src_wrp = NiftiWrapper(src_nii)
     except MissingExtensionError:
-        print "No dcmmeta extension found, making empty one..."
+        print("No dcmmeta extension found, making empty one...")
         src_wrp = NiftiWrapper(src_nii, make_empty=True)
     for split_idx, split in enumerate(src_wrp.split(args.dimension)):
         if args.output_format:
@@ -137,7 +139,7 @@ def merge(args):
         try:
             src_wrp = NiftiWrapper(src_nii)
         except MissingExtensionError:
-            print "No dcmmeta extension found, making empty one..."
+            print("No dcmmeta extension found, making empty one...")
             src_wrp = NiftiWrapper(src_nii, make_empty=True)
         src_wrps.append(src_wrp)
 
@@ -169,7 +171,7 @@ def dump(args):
 def check_overwrite():
     usr_input = ''
     while not usr_input in ('y', 'n'):
-        usr_input = raw_input('Existing DcmMeta extension found, overwrite? '
+        usr_input = input('Existing DcmMeta extension found, overwrite? '
                               '[y/n]').lower()
     return usr_input == 'y'
 
@@ -197,7 +199,7 @@ def lookup(args):
         index = tuple(int(idx.strip()) for idx in args.index.split(','))
     meta = src_wrp.get_meta(args.key[0], index)
     if not meta is None:
-        print meta
+        print(meta)
     return 0
 
 def convert_values(values, type_str=None):
@@ -223,18 +225,18 @@ def inject(args):
     dest_wrp = NiftiWrapper(dest_nii, make_empty=True)
     classification = tuple(args.classification)
     if not classification in dest_wrp.meta_ext.get_valid_classes():
-        print "Invalid classification: %s" % (classification,)
+        print("Invalid classification: %s" % (classification,))
         return 1
     n_vals = len(args.values)
     mult = dest_wrp.meta_ext.get_multiplicity(classification)
     if n_vals != mult:
-        print ("Invalid number of values for classification. Expected "
-               "%d but got %d") % (mult, n_vals)
+        print(("Invalid number of values for classification. Expected "
+               "%d but got %d") % (mult, n_vals))
         return 1
     key = args.key[0]
     if key in dest_wrp.meta_ext.get_keys():
         if not args.force_overwrite:
-            print "Key already exists, must pass --force-overwrite"
+            print("Key already exists, must pass --force-overwrite")
             return 1
         else:
             curr_class = dest_wrp.meta_ext.get_classification(key)


### PR DESCRIPTION
This PR aggregates the list of changes I had to make to be able to call `dcmstack` within a Python 3 virtualenv.