### PR TITLE
Introduce and use properties (for shape, affine, header) to avoid nibabel deprecation warnings

### DIFF
--- a/doc/Python_Tutorial.rst
+++ b/doc/Python_Tutorial.rst
@@ -62,7 +62,7 @@ the array of voxel data, get the affine transform, or create a Nifti1Image.
 .. code-block:: python
     
     >>> stack_data = my_stack.get_data()
-    >>> stack_affine = my_stack.get_affine()
+    >>> stack_affine = my_stack.affine
     >>> nii = my_stack.to_nifti()
     
 Embedding Meta Data

--- a/doc/Python_Tutorial.rst
+++ b/doc/Python_Tutorial.rst
@@ -150,25 +150,25 @@ method *split*.
     >>> from dcmstack.dcmmeta import NiftiWrapper
     >>> nw1 = NiftiWrapper.from_filename('img1.nii.gz')
     >>> nw2 = NiftiWrapper.from_filename('img2.nii.gz')
-    >>> print nw1.nii_img.get_shape()
+    >>> print nw1.nii_img.shape
     (384, 512, 60)
-    >>> print nw2.nii_img.get_shape()
+    >>> print nw2.nii_img.shape
     (384, 512, 60)
     >>> print nw1.get_meta('EchoTime')
     11.0
     >>> print nw2.get_meta('EchoTime')
     87.0
     >>> merged = NiftiWrapper.from_sequence([nw1, nw2])
-    >>> print merged.nii_img.get_shape()
+    >>> print merged.nii_img.shape
     (384, 512, 60, 2)
     >>> print merged.get_meta('EchoTime', index=(0,0,0,0)
     11.0
     >>> print merged.get_meta('EchoTime', index=(0,0,0,1)
     87.0
     >>> splits = list(merge.split())
-    >>> print splits[0].nii_img.get_shape()
+    >>> print splits[0].nii_img.shape
     (384, 512, 60)
-    >>> print splits[1].nii_img.get_shape()
+    >>> print splits[1].nii_img.shape
     (384, 512, 60)
     >>> print splits[0].get_meta('EchoTime')
     11.0

--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1292,7 +1292,7 @@ class NiftiWrapper(object):
         if classification == ('global', 'const'):
             return True
 
-        img_shape = self.nii_img.get_shape()
+        img_shape = self.nii_img.shape
         meta_shape = self.meta_ext.shape
         if classification == ('vector', 'samples'):
             return meta_shape[4:] == img_shape[4:]
@@ -1357,7 +1357,7 @@ class NiftiWrapper(object):
         #If an index is provided check the varying values
         if not index is None:
             #Test if the index is valid
-            shape = self.nii_img.get_shape()
+            shape = self.nii_img.shape
             if len(index) != len(shape):
                 raise IndexError('Incorrect number of indices.')
             for dim, ind_val in enumerate(index):
@@ -1434,7 +1434,7 @@ class NiftiWrapper(object):
             along `dim`.
 
         '''
-        shape = self.nii_img.get_shape()
+        shape = self.nii_img.shape
         data = self.nii_img.get_data()
         header = self.nii_img.header
         slice_dim = header.get_dim_info()[2]

--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1533,7 +1533,7 @@ class NiftiWrapper(object):
         data = dcm_wrp.get_data()
 
         #The Nifti patient space flips the x and y directions
-        affine = np.dot(np.diag([-1., -1., 1., 1.]), dcm_wrp.affine)
+        affine = np.dot(np.diag([-1., -1., 1., 1.]), dcm_wrp.get_affine())
 
         #Make 2D data 3D
         if len(data.shape) == 2:

--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1253,7 +1253,7 @@ class NiftiWrapper(object):
 
     def __init__(self, nii_img, make_empty=False):
         self.nii_img = nii_img
-        hdr = nii_img.get_header()
+        hdr = nii_img.header
         self.meta_ext = None
         for extension in hdr.extensions:
             if extension.get_code() == dcm_meta_ecode:
@@ -1299,7 +1299,7 @@ class NiftiWrapper(object):
         if classification == ('time', 'samples'):
             return meta_shape[3:] == img_shape[3:]
 
-        hdr = self.nii_img.get_header()
+        hdr = self.nii_img.header
         if self.meta_ext.n_slices != hdr.get_n_slices():
             return False
 
@@ -1371,7 +1371,7 @@ class NiftiWrapper(object):
                 return values[index[4]]
 
             #Finally, if aligned, try per-slice values
-            slice_dim = self.nii_img.get_header().get_dim_info()[2]
+            slice_dim = self.nii_img.header.get_dim_info()[2]
             n_slices = shape[slice_dim]
             if classes == ('global', 'slices'):
                 val_idx = index[slice_dim]
@@ -1392,7 +1392,7 @@ class NiftiWrapper(object):
     def remove_extension(self):
         '''Remove the DcmMetaExtension from the header of nii_img. The
         attribute `meta_ext` will still point to the extension.'''
-        hdr = self.nii_img.get_header()
+        hdr = self.nii_img.header
         target_idx = None
         for idx, ext in enumerate(hdr.extensions):
             if id(ext) == id(self.meta_ext):
@@ -1414,7 +1414,7 @@ class NiftiWrapper(object):
 
         '''
         self.remove_extension()
-        self.nii_img.get_header().extensions.append(dcmmeta_ext)
+        self.nii_img.header.extensions.append(dcmmeta_ext)
         self.meta_ext = dcmmeta_ext
 
     def split(self, dim=None):
@@ -1436,7 +1436,7 @@ class NiftiWrapper(object):
         '''
         shape = self.nii_img.get_shape()
         data = self.nii_img.get_data()
-        header = self.nii_img.get_header()
+        header = self.nii_img.header
         slice_dim = header.get_dim_info()[2]
 
         #If dim is None, choose the vector/time/slice dim in that order
@@ -1541,7 +1541,7 @@ class NiftiWrapper(object):
 
         #Create the nifti image and set header data
         nii_img = nb.nifti1.Nifti1Image(data, affine)
-        hdr = nii_img.get_header()
+        hdr = nii_img.header
         hdr.set_xyzt_units('mm', 'sec')
         dim_info = {'freq' : None,
                     'phase' : None,
@@ -1606,7 +1606,7 @@ class NiftiWrapper(object):
         n_inputs = len(seq)
         first_input = seq[0]
         first_nii = first_input.nii_img
-        first_hdr = first_nii.get_header()
+        first_hdr = first_nii.header
         shape = first_nii.shape
         affine = first_nii.get_affine().copy()
 
@@ -1684,7 +1684,7 @@ class NiftiWrapper(object):
             input_wrp = seq[input_idx]
             input_nii = input_wrp.nii_img
             input_aff = input_nii.get_affine()
-            input_hdr = input_nii.get_header()
+            input_hdr = input_nii.header
 
             #Check that the affines match appropriately
             for axis_idx, axis_vec in enumerate(axes):
@@ -1773,7 +1773,7 @@ class NiftiWrapper(object):
 
         #Create the resulting Nifti and wrapper
         result_nii = nb.Nifti1Image(result_data, affine)
-        result_hdr = result_nii.get_header()
+        result_hdr = result_nii.header
 
         #Update the header with any info that is consistent across inputs
         if hdr_info['qform'] is not None and hdr_info['qform_code'] is not None:

--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1304,7 +1304,7 @@ class NiftiWrapper(object):
             return False
 
         slice_dim = hdr.get_dim_info()[2]
-        slice_dir = self.nii_img.get_affine()[slice_dim, :3]
+        slice_dir = self.nii_img.affine[slice_dim, :3]
         slices_aligned = np.allclose(slice_dir,
                                      self.meta_ext.slice_normal,
                                      atol=1e-6)
@@ -1533,7 +1533,7 @@ class NiftiWrapper(object):
         data = dcm_wrp.get_data()
 
         #The Nifti patient space flips the x and y directions
-        affine = np.dot(np.diag([-1., -1., 1., 1.]), dcm_wrp.get_affine())
+        affine = np.dot(np.diag([-1., -1., 1., 1.]), dcm_wrp.affine)
 
         #Make 2D data 3D
         if len(data.shape) == 2:
@@ -1608,7 +1608,7 @@ class NiftiWrapper(object):
         first_nii = first_input.nii_img
         first_hdr = first_nii.header
         shape = first_nii.shape
-        affine = first_nii.get_affine().copy()
+        affine = first_nii.affine.copy()
 
         #If dim is None, choose a sane default
         if dim is None:
@@ -1683,7 +1683,7 @@ class NiftiWrapper(object):
 
             input_wrp = seq[input_idx]
             input_nii = input_wrp.nii_img
-            input_aff = input_nii.get_affine()
+            input_aff = input_nii.affine
             input_hdr = input_nii.header
 
             #Check that the affines match appropriately
@@ -1768,7 +1768,7 @@ class NiftiWrapper(object):
         #If we joined along a spatial dim, rescale the appropriate axis
         scaled_dim_dir = None
         if dim < 3:
-            scaled_dim_dir = seq[1].nii_img.get_affine()[:3, 3] - trans
+            scaled_dim_dir = seq[1].nii_img.affine[:3, 3] - trans
             affine[:3, dim] = scaled_dim_dir
 
         #Create the resulting Nifti and wrapper

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -764,6 +764,8 @@ class DicomStack(object):
         self._shape_dirty = False
         return self._shape
 
+    shape = property(fget=get_shape)
+
     def get_data(self):
         '''Get an array of the voxel values.
 
@@ -817,6 +819,8 @@ class DicomStack(object):
 
         return vox_array
 
+    data = property(fget=get_data)
+
     def get_affine(self):
         '''Get the affine transform for mapping row/column/slice indices
         to Nifti (RAS) patient space.
@@ -852,6 +856,8 @@ class DicomStack(object):
             aff[:3, 2] = scaled_slc_dir
 
         return aff
+
+    affine = property(fget=get_affine)
 
     def to_nifti(self, voxel_order='LAS', embed_meta=False):
         '''Returns a NiftiImage with the data and affine from the stack.

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -356,7 +356,7 @@ def _make_dummy(reference, meta, iop):
     data[...] = np.iinfo(np.int16).max
 
     #Create the nifti image and set header data
-    aff = reference.nii_img.get_affine().copy()
+    aff = reference.nii_img.affine.copy()
     aff[:3, 3] = [iop[1], iop[0], iop[2]]
     nii_img = nb.nifti1.Nifti1Image(data, aff)
     hdr = nii_img.header
@@ -842,12 +842,12 @@ class DicomStack(object):
         files_per_vol = len(self._files_info) // n_vols
 
         #Pull the DICOM Patient Space affine from the first input
-        aff = self._files_info[0][0].nii_img.get_affine()
+        aff = self._files_info[0][0].nii_img.affine
 
         #If there is more than one file per volume, we need to fix slice scaling
         if files_per_vol > 1:
             first_offset = aff[:3, 3]
-            second_offset = self._files_info[1][0].nii_img.get_affine()[:3, 3]
+            second_offset = self._files_info[1][0].nii_img.affine[:3, 3]
             scaled_slc_dir = second_offset - first_offset
             aff[:3, 2] = scaled_slc_dir
 
@@ -873,7 +873,7 @@ class DicomStack(object):
         '''
         #Get the voxel data and affine
         data = self.get_data()
-        affine = self.get_affine()
+        affine = self.affine
 
         #Figure out the number of three (or two) dimensional volumes
         n_vols = 1

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -750,7 +750,7 @@ class DicomStack(object):
                             num_vec_comps)
 
         #Stack appears to be valid, build the shape tuple
-        file_shape = self._files_info[0][0].nii_img.get_shape()
+        file_shape = self._files_info[0][0].nii_img.shape
         vol_shape = list(file_shape)
         if files_per_vol > 1:
             vol_shape[2] = files_per_vol
@@ -777,7 +777,7 @@ class DicomStack(object):
             The stack is incomplete or invalid.
         '''
         #Create a numpy array for storing the voxel data
-        stack_shape = self.get_shape()
+        stack_shape = self.shape
         stack_shape = tuple(list(stack_shape) + ((5 - len(stack_shape)) * [1]))
         stack_dtype = self._files_info[0][0].nii_img.get_data_dtype()
         bits_stored = self._files_info[0][0].get_meta('BitsStored', default=16)
@@ -795,7 +795,7 @@ class DicomStack(object):
         if len(stack_shape) > 4:
             n_vols *= stack_shape[4]
         files_per_vol = len(self._files_info) // n_vols
-        file_shape = self._files_info[0][0].nii_img.get_shape()
+        file_shape = self._files_info[0][0].nii_img.shape
         for vec_idx in range(stack_shape[4]):
             for time_idx in range(stack_shape[3]):
                 if files_per_vol == 1 and file_shape[2] != 1:
@@ -831,7 +831,7 @@ class DicomStack(object):
             The stack is incomplete or invalid.
         '''
         #Figure out the number of three (or two) dimensional volumes
-        shape = self.get_shape()
+        shape = self.shape
         n_vols = 1
         if len(shape) > 3:
             n_vols *= shape[3]

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -988,7 +988,7 @@ class DicomStack(object):
                     for vec_idx in range(data.shape[4]):
                         start_idx = vec_idx * data.shape[3]
                         end_idx = start_idx + data.shape[3]
-                        meta = DcmMetaExtension.from_sequence(\
+                        meta = DcmMetaExtension.from_sequence(
                             vol_meta[start_idx:end_idx], 3)
                         vec_meta.append(meta)
                 else:

--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -359,7 +359,7 @@ def _make_dummy(reference, meta, iop):
     aff = reference.nii_img.get_affine().copy()
     aff[:3, 3] = [iop[1], iop[0], iop[2]]
     nii_img = nb.nifti1.Nifti1Image(data, aff)
-    hdr = nii_img.get_header()
+    hdr = nii_img.header
     hdr.set_xyzt_units('mm', 'sec')
     dim_info = {'freq' : None,
                 'phase' : None,
@@ -914,7 +914,7 @@ class DicomStack(object):
 
         #Create the nifti image using the data array
         nifti_image = nb.Nifti1Image(data, affine)
-        nifti_header = nifti_image.get_header()
+        nifti_header = nifti_image.header
 
         #Set the units and dimension info
         nifti_header.set_xyzt_units('mm', 'msec')

--- a/src/dcmstack/info.py
+++ b/src/dcmstack/info.py
@@ -24,7 +24,7 @@ description = 'Stack DICOM images into volumes and convert to Nifti'
 
 # Hard dependencies
 install_requires = ['pydicom >= 0.9.7',
-                    'nibabel >= 2.0.0',
+                    'nibabel >= 2.1.0',
                    ]
 # Add version specific dependencies
 if sys.version_info < (2, 6):

--- a/src/dcmstack/nitool_cli.py
+++ b/src/dcmstack/nitool_cli.py
@@ -179,7 +179,7 @@ def check_overwrite():
 
 def embed(args):
     dest_nii = nb.load(args.dest_nii[0])
-    hdr = dest_nii.get_header()
+    hdr = dest_nii.header
     try:
         src_wrp = NiftiWrapper(dest_nii, False)
     except MissingExtensionError:

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -908,7 +908,7 @@ def test_nifti_wrapper_init():
     assert_raises(dcmmeta.MissingExtensionError,
                   dcmmeta.NiftiWrapper,
                   nii)
-    hdr = nii.get_header()
+    hdr = nii.header
     ext = dcmmeta.DcmMetaExtension.make_empty((5, 5, 5), np.eye(4))
     hdr.extensions.append(ext)
     nw = dcmmeta.NiftiWrapper(nii)
@@ -922,7 +922,7 @@ def test_nifti_wrapper_init():
 class TestMetaValid(object):
     def setUp(self):
         nii = nb.Nifti1Image(np.zeros((5, 5, 5, 7, 9)), np.eye(4))
-        hdr = nii.get_header()
+        hdr = nii.header
         hdr.set_dim_info(None, None, 2)
         self.nw = dcmmeta.NiftiWrapper(nii, True)
         for classes in self.nw.meta_ext.get_valid_classes():
@@ -973,7 +973,7 @@ class TestMetaValid(object):
 class TestGetMeta(object):
     def setUp(self):
         nii = nb.Nifti1Image(np.zeros((5, 5, 5, 7, 9)), np.eye(4))
-        hdr = nii.get_header()
+        hdr = nii.header
         hdr.set_dim_info(None, None, 2)
         self.nw = dcmmeta.NiftiWrapper(nii, True)
 
@@ -1075,7 +1075,7 @@ class TestSplit(object):
     def setUp(self):
         self.arr = np.arange(3 * 3 * 3 * 5 * 7).reshape(3, 3, 3, 5, 7)
         nii = nb.Nifti1Image(self.arr, np.diag([1.1, 1.1, 1.1, 1.0]))
-        hdr = nii.get_header()
+        hdr = nii.header
         hdr.set_dim_info(None, None, 2)
         self.nw = dcmmeta.NiftiWrapper(nii, True)
 
@@ -1141,7 +1141,7 @@ def test_from_dicom():
     src_dw = nb.nicom.dicomwrappers.wrapper_from_data(src_dcm)
     meta = {'EchoTime': 40}
     nw = dcmmeta.NiftiWrapper.from_dicom(src_dcm, meta)
-    hdr = nw.nii_img.get_header()
+    hdr = nw.nii_img.header
     eq_(nw.nii_img.get_shape(), (192, 192, 1))
     ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.get_affine()),
                     nw.nii_img.get_affine())
@@ -1159,7 +1159,7 @@ def test_from_2d_slice_to_3d():
         aff = np.diag((1.1, 1.1, 1.1, 1.0))
         aff[:3, 3] += [0.0, 0.0, idx * 0.5]
         nii = nb.Nifti1Image(arr, aff)
-        hdr = nii.get_header()
+        hdr = nii.header
         hdr.set_dim_info(0, 1, 2)
         hdr.set_xyzt_units('mm', 'sec')
         nw = dcmmeta.NiftiWrapper(nii, True)
@@ -1178,7 +1178,7 @@ def test_from_2d_slice_to_3d():
     eq_(merged.meta_ext.get_values_and_class('SliceLocation'),
         (list(range(3)), ('global', 'slices'))
        )
-    merged_hdr = merged.nii_img.get_header()
+    merged_hdr = merged.nii_img.header
     eq_(merged_hdr.get_dim_info(), (0, 1, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
     merged_data = merged.nii_img.get_data()
@@ -1194,7 +1194,7 @@ def test_from_3d_time_to_4d():
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
         nii = nb.Nifti1Image(arr, np.diag((1.1, 1.1, 1.1, 1.0)))
-        hdr = nii.get_header()
+        hdr = nii.header
         hdr.set_dim_info(0, 1, 2)
         hdr.set_xyzt_units('mm', 'sec')
         nw = dcmmeta.NiftiWrapper(nii, True)
@@ -1223,7 +1223,7 @@ def test_from_3d_time_to_4d():
     eq_(merged.meta_ext.get_values_and_class('AcquisitionTime'),
         (list(range(4 * 3)), ('global', 'slices'))
        )
-    merged_hdr = merged.nii_img.get_header()
+    merged_hdr = merged.nii_img.header
     eq_(merged_hdr.get_dim_info(), (0, 1, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
     merged_data = merged.nii_img.get_data()
@@ -1240,7 +1240,7 @@ def test_from_3d_vector_to_4d():
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
         nii = nb.Nifti1Image(arr, np.diag((1.1, 1.1, 1.1, 1.0)))
-        hdr = nii.get_header()
+        hdr = nii.header
         hdr.set_dim_info(0, 1, 2)
         hdr.set_xyzt_units('mm', 'sec')
         nw = dcmmeta.NiftiWrapper(nii, True)
@@ -1269,7 +1269,7 @@ def test_from_3d_vector_to_4d():
     eq_(merged.meta_ext.get_values_and_class('AcquisitionTime'),
         (list(range(4 * 3)), ('global', 'slices'))
        )
-    merged_hdr = merged.nii_img.get_header()
+    merged_hdr = merged.nii_img.header
     eq_(merged_hdr.get_dim_info(), (0, 1, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
     merged_data = merged.nii_img.get_data()
@@ -1288,7 +1288,7 @@ def test_merge_inconsistent_hdr():
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
         nii = nb.Nifti1Image(arr, np.diag((1.1, 1.1, 1.1, 1.0)))
-        hdr = nii.get_header()
+        hdr = nii.header
         if idx == 1:
             hdr.set_dim_info(1, 0, 2)
             hdr.set_xyzt_units('mm', None)
@@ -1299,7 +1299,7 @@ def test_merge_inconsistent_hdr():
         time_nws.append(nw)
 
     merged = dcmmeta.NiftiWrapper.from_sequence(time_nws)
-    merged_hdr = merged.nii_img.get_header()
+    merged_hdr = merged.nii_img.header
     eq_(merged_hdr.get_dim_info(), (None, None, 2))
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'unknown'))
 
@@ -1311,7 +1311,7 @@ def test_merge_with_slc_and_without():
                         (idx + 1) * (4 * 4 * 4)
                        ).reshape(4, 4, 4)
         nii = nb.Nifti1Image(arr, np.diag((1.1, 1.1, 1.1, 1.0)))
-        hdr = nii.get_header()
+        hdr = nii.header
         if idx == 0:
             hdr.set_dim_info(0, 1, 2)
         hdr.set_xyzt_units('mm', 'sec')
@@ -1338,5 +1338,5 @@ def test_merge_with_slc_and_without():
     eq_(merged.meta_ext.get_values_and_class('SliceLocation'),
         (list(range(4)) + ([None] * 8), ('global', 'slices'))
        )
-    merged_hdr = merged.nii_img.get_header()
+    merged_hdr = merged.nii_img.header
     eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -957,7 +957,7 @@ class TestMetaValid(object):
                 ok_(self.nw.meta_valid(classes))
 
     def test_slice_dir_changed(self):
-        aff = self.nw.nii_img.get_affine()
+        aff = self.nw.nii_img.affine
         aff[:] = np.c_[aff[2, :],
                        aff[1, :],
                        aff[0, :],
@@ -1092,7 +1092,7 @@ class TestSplit(object):
     def test_split_slice(self):
         for split_idx, nw_split in enumerate(self.nw.split(2)):
             eq_(nw_split.nii_img.shape, (3, 3, 1, 5, 7))
-            ok_(np.allclose(nw_split.nii_img.get_affine(),
+            ok_(np.allclose(nw_split.nii_img.affine,
                             np.c_[[1.1, 0.0, 0.0, 0.0],
                                   [0.0, 1.1, 0.0, 0.0],
                                   [0.0, 0.0, 1.1, 0.0],
@@ -1107,7 +1107,7 @@ class TestSplit(object):
     def test_split_time(self):
         for split_idx, nw_split in enumerate(self.nw.split(3)):
             eq_(nw_split.nii_img.shape, (3, 3, 3, 1, 7))
-            ok_(np.allclose(nw_split.nii_img.get_affine(),
+            ok_(np.allclose(nw_split.nii_img.affine,
                             np.diag([1.1, 1.1, 1.1, 1.0])))
             ok_(np.all(nw_split.nii_img.get_data() ==
                        self.arr[:, :, :, split_idx:split_idx+1, :])
@@ -1116,7 +1116,7 @@ class TestSplit(object):
     def test_split_vector(self):
         for split_idx, nw_split in enumerate(self.nw.split(4)):
             eq_(nw_split.nii_img.shape, (3, 3, 3, 5))
-            ok_(np.allclose(nw_split.nii_img.get_affine(),
+            ok_(np.allclose(nw_split.nii_img.affine,
                             np.diag([1.1, 1.1, 1.1, 1.0])))
             ok_(np.all(nw_split.nii_img.get_data() ==
                        self.arr[:, :, :, :, split_idx])
@@ -1143,8 +1143,8 @@ def test_from_dicom():
     nw = dcmmeta.NiftiWrapper.from_dicom(src_dcm, meta)
     hdr = nw.nii_img.header
     eq_(nw.nii_img.shape, (192, 192, 1))
-    ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.get_affine()),
-                    nw.nii_img.get_affine())
+    ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.affine),
+                    nw.nii_img.affine)
        )
     eq_(hdr.get_xyzt_units(), ('mm', 'sec'))
     eq_(hdr.get_dim_info(), (0, 1, 2))
@@ -1169,7 +1169,7 @@ def test_from_2d_slice_to_3d():
 
     merged = dcmmeta.NiftiWrapper.from_sequence(slice_nws, 2)
     eq_(merged.nii_img.shape, (4, 4, 3))
-    ok_(np.allclose(merged.nii_img.get_affine(),
+    ok_(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 0.5, 1.0)))
        )
     eq_(merged.meta_ext.get_values_and_class('EchoTime'),
@@ -1208,7 +1208,7 @@ def test_from_3d_time_to_4d():
 
     merged = dcmmeta.NiftiWrapper.from_sequence(time_nws, 3)
     eq_(merged.nii_img.shape, (4, 4, 4, 3))
-    ok_(np.allclose(merged.nii_img.get_affine(),
+    ok_(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 1.1, 1.0)))
        )
     eq_(merged.meta_ext.get_values_and_class('PatientID'),
@@ -1254,7 +1254,7 @@ def test_from_3d_vector_to_4d():
 
     merged = dcmmeta.NiftiWrapper.from_sequence(vector_nws, 4)
     eq_(merged.nii_img.shape, (4, 4, 4, 1, 3))
-    ok_(np.allclose(merged.nii_img.get_affine(),
+    ok_(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 1.1, 1.0)))
        )
     eq_(merged.meta_ext.get_values_and_class('PatientID'),
@@ -1326,7 +1326,7 @@ def test_merge_with_slc_and_without():
 
     merged = dcmmeta.NiftiWrapper.from_sequence(input_nws)
     eq_(merged.nii_img.shape, (4, 4, 4, 3))
-    ok_(np.allclose(merged.nii_img.get_affine(),
+    ok_(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 1.1, 1.0)))
        )
     eq_(merged.meta_ext.get_values_and_class('PatientID'),

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -1142,7 +1142,7 @@ def test_from_dicom():
     meta = {'EchoTime': 40}
     nw = dcmmeta.NiftiWrapper.from_dicom(src_dcm, meta)
     hdr = nw.nii_img.header
-    eq_(nw.nii_img.get_shape(), (192, 192, 1))
+    eq_(nw.nii_img.shape, (192, 192, 1))
     ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.get_affine()),
                     nw.nii_img.get_affine())
        )

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -1143,7 +1143,7 @@ def test_from_dicom():
     nw = dcmmeta.NiftiWrapper.from_dicom(src_dcm, meta)
     hdr = nw.nii_img.header
     eq_(nw.nii_img.shape, (192, 192, 1))
-    ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.affine),
+    ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.get_affine()),
                     nw.nii_img.affine)
        )
     eq_(hdr.get_xyzt_units(), ('mm', 'sec'))

--- a/test/test_dcmstack.py
+++ b/test/test_dcmstack.py
@@ -365,14 +365,14 @@ class TestGetShape(object):
     def test_single_slice(self):
         stack = dcmstack.DicomStack()
         stack.add_dcm(self.inputs[0])
-        shape = stack.get_shape()
+        shape = stack.shape
         eq_(shape, (192, 192, 1))
 
     def test_three_dim(self):
         stack = dcmstack.DicomStack()
         stack.add_dcm(self.inputs[0])
         stack.add_dcm(self.inputs[1])
-        shape = stack.get_shape()
+        shape = stack.shape
         eq_(shape, (192, 192, 2))
 
     def test_four_dim(self):
@@ -381,7 +381,7 @@ class TestGetShape(object):
         stack.add_dcm(self.inputs[1])
         stack.add_dcm(self.inputs[2])
         stack.add_dcm(self.inputs[3])
-        shape = stack.get_shape()
+        shape = stack.shape
         eq_(shape, (192, 192, 2, 2))
 
     def test_five_dim(self):
@@ -390,7 +390,7 @@ class TestGetShape(object):
         stack.add_dcm(self.inputs[1])
         stack.add_dcm(self.inputs[2])
         stack.add_dcm(self.inputs[3])
-        shape = stack.get_shape()
+        shape = stack.shape
         eq_(shape, (192, 192, 2, 1, 2))
 
     def test_allow_dummy(self):
@@ -399,7 +399,7 @@ class TestGetShape(object):
         stack = dcmstack.DicomStack(allow_dummies=True)
         stack.add_dcm(self.inputs[0])
         stack.add_dcm(self.inputs[1])
-        shape = stack.get_shape()
+        shape = stack.shape
         eq_(shape, (192, 192, 2))
 
 class TestGuessDim(object):
@@ -435,7 +435,7 @@ class TestGuessDim(object):
             for idx, in_dcm in enumerate(self.inputs):
                 setattr(in_dcm, key, self._get_vr_ord(key, idx))
                 stack.add_dcm(in_dcm)
-            eq_(stack.get_shape(), (192, 192, 2, 2))
+            eq_(stack.shape, (192, 192, 2, 2))
             for in_dcm in self.inputs:
                 delattr(in_dcm, key)
 
@@ -450,7 +450,7 @@ class TestGuessDim(object):
                     dcmstack.DicomStack.sort_guesses[-1],
                     self._get_vr_ord(key, idx) )
             stack.add_dcm(in_dcm)
-        eq_(stack.get_shape(), (192, 192, 2, 2))
+        eq_(stack.shape, (192, 192, 2, 2))
 
 class TestGetData(object):
     def setUp(self):
@@ -470,7 +470,7 @@ class TestGetData(object):
         stack = dcmstack.DicomStack()
         stack.add_dcm(self.inputs[0])
         data = stack.get_data()
-        eq_(data.shape, stack.get_shape())
+        eq_(data.shape, stack.shape)
         eq_(sha256(data).hexdigest(),
             '15cfa107ca73810a1c97f1c1872a7a4a05808ba6147e039cef3f63fa08735f5d')
 
@@ -479,7 +479,7 @@ class TestGetData(object):
         stack.add_dcm(self.inputs[0])
         stack.add_dcm(self.inputs[1])
         data = stack.get_data()
-        eq_(data.shape, stack.get_shape())
+        eq_(data.shape, stack.shape)
         eq_(sha256(data).hexdigest(),
             'ab5225fdbedceeea3442b2c9387e1abcbf398c71f525e0017251849c3cfbf49c')
 
@@ -490,7 +490,7 @@ class TestGetData(object):
         stack.add_dcm(self.inputs[2])
         stack.add_dcm(self.inputs[3])
         data = stack.get_data()
-        eq_(data.shape, stack.get_shape())
+        eq_(data.shape, stack.shape)
         eq_(sha256(data).hexdigest(),
             'bb3639a6ece13dc9a11d65f1b09ab3ccaed63b22dcf0f96fb5d3dd8805cc7b8a')
 
@@ -501,7 +501,7 @@ class TestGetData(object):
         stack.add_dcm(self.inputs[2])
         stack.add_dcm(self.inputs[3])
         data = stack.get_data()
-        eq_(data.shape, stack.get_shape())
+        eq_(data.shape, stack.shape)
         eq_(sha256(data).hexdigest(),
             'bb3639a6ece13dc9a11d65f1b09ab3ccaed63b22dcf0f96fb5d3dd8805cc7b8a')
 
@@ -512,7 +512,7 @@ class TestGetData(object):
         stack.add_dcm(self.inputs[0])
         stack.add_dcm(self.inputs[1])
         data = stack.get_data()
-        eq_(data.shape, stack.get_shape())
+        eq_(data.shape, stack.shape)
         ok_(np.all(data[:, :, -1] == np.iinfo(np.int16).max))
         eq_(sha256(data).hexdigest(),
             '7d85fbcb60a5021a45df3975613dcb7ac731830e0a268590cc798dc39897c04b')

--- a/test/test_dcmstack.py
+++ b/test/test_dcmstack.py
@@ -532,7 +532,7 @@ class TestGetAffine(object):
     def test_single_slice(self):
         stack = dcmstack.DicomStack()
         stack.add_dcm(self.inputs[0])
-        affine = stack.get_affine()
+        affine = stack.affine
         ref = np.load(path.join(self.data_dir, 'single_slice_aff.npy'))
         ok_(np.allclose(affine, ref))
 
@@ -540,7 +540,7 @@ class TestGetAffine(object):
         stack = dcmstack.DicomStack()
         stack.add_dcm(self.inputs[0])
         stack.add_dcm(self.inputs[1])
-        affine = stack.get_affine()
+        affine = stack.affine
         ref = np.load(path.join(self.data_dir, 'single_vol_aff.npy'))
         ok_(np.allclose(affine, ref))
 

--- a/test/test_dcmstack.py
+++ b/test/test_dcmstack.py
@@ -625,9 +625,9 @@ class TestToNifti(object):
         assert False # Unknown name
 
     def _chk(self, nii, ref_base_fn):
-        hdr = nii.get_header()
+        hdr = nii.header
         ref_nii = nb.load(path.join(self.data_dir, ref_base_fn) + '.nii.gz')
-        ref_hdr = ref_nii.get_header()
+        ref_hdr = ref_nii.header
 
         for key in self.eq_keys:
             print("Testing key %s" % key)


### PR DESCRIPTION
Introduced properties to ease RFing and also make this interface more inline with nibabel.  More comments in the individual commits