### PR TITLE
Use `.affine`, rather than `.get_affine()`

### DIFF
--- a/src/dcmstack/dcmmeta.py
+++ b/src/dcmstack/dcmmeta.py
@@ -1533,7 +1533,7 @@ class NiftiWrapper(object):
         data = dcm_wrp.get_data()
 
         #The Nifti patient space flips the x and y directions
-        affine = np.dot(np.diag([-1., -1., 1., 1.]), dcm_wrp.get_affine())
+        affine = np.dot(np.diag([-1., -1., 1., 1.]), dcm_wrp.affine)
 
         #Make 2D data 3D
         if len(data.shape) == 2:


### PR DESCRIPTION
Deprecated in [NiBabel 2.5.1](https://github.com/nipy/nibabel/commit/dc36a28edf3c1dd827ad49df8ade44cb556c0ea2)