### PR TITLE
BF: parse_and_group - explicit comparison to being Nones before np.allclose

### DIFF
--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -1144,7 +1144,10 @@ def parse_and_group(src_paths, group_by=default_group_keys, extractor=None,
             # Look for a matching sub_result
             for c_list, sub_res in results[key]:
                 for c_idx, c_val in enumerate(c_list):
-                    if not np.allclose(c_val, close_list[c_idx], atol=5e-5):
+                    if not (
+                        (c_val is None and close_list[c_idx] is None) or
+                        np.allclose(c_val, close_list[c_idx], atol=5e-5)
+                    ):
                         break
                 else:
                     sub_res.append((dcm, meta, dcm_path))


### PR DESCRIPTION
This situation was encountered in https://github.com/nipy/heudiconv/issues/582
where we got Nones for both values but then np.allclose errored out to compare
on them due to

      File "<__array_function__ internals>", line 180, in isclose
      File "/home/yoh/proj/heudiconv/heudiconv-master/venvs/dev3/lib/python3.10/site-packages/numpy/core/numeric.py", line 2372, in isclose
        xfin = isfinite(x)
        TypeError: ufunc 'isfinite' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''

as a logical workaround I have decided to add an explicit check for them both
being None.  There may be could be cases where one of them would be None or
other cases where similarly np.allclose is done without similar guarding.  If
encountered, a better comparator should be introduced, but for this this
addresses that original issue in heudiconv.