### PR TITLE
Migrate to pytest from nose

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[options.extras_require]
+test =
+    pytest
+    pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(name=NAME,
                            'nitool = dcmstack.nitool_cli:main',
                           ],
                      },
-      test_suite = 'nose.collector'
+      test_suite = 'pytest'
      )

--- a/src/dcmstack/info.py
+++ b/src/dcmstack/info.py
@@ -34,7 +34,7 @@ elif sys.version_info < (2, 7):
 
 # Extra requirements for building documentation and testing
 extras_requires = {'doc':  ["sphinx", "numpydoc"],
-                   'test': ["nose"],
+                   'test': ["pytest"],
                   }
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,8 +5,6 @@ from glob import glob
 
 import numpy as np
 
-from nose.tools import ok_, eq_
-
 from . import test_dir, src_dir
 
 from dcmstack import dcmstack_cli, nitool_cli
@@ -55,11 +53,11 @@ class CliTest(object):
 class TestDcmstackCli(CliTest):
     def test_basic(self):
         nii_paths = make_niftis(self.out_dir)
-        eq_(len(nii_paths), 1)
+        assert len(nii_paths) == 1
 
     def test_embed(self):
         nii_paths = make_niftis(self.out_dir, ['--embed'])
-        eq_(len(nii_paths), 1)
+        assert len(nii_paths) == 1
 
 
 class TestNitoolCli(CliTest):
@@ -70,11 +68,11 @@ class TestNitoolCli(CliTest):
         with open(json_path) as fp:
             meta = json.load(fp)
         print(json.dumps(meta, indent=4))
-        ok_('dcmmeta_version' in meta)
-        ok_('dcmmeta_affine' in meta)
-        ok_('dcmmeta_reorient_transform' in meta)
-        eq_(meta['dcmmeta_shape'], [192, 192, 2, 2])
-        eq_(meta['dcmmeta_slice_dim'], 2)
-        eq_(meta['global']['const']['Rows'], 192)
-        eq_(meta['global']['const']['Columns'], 192)
-        ok_(np.allclose(meta['time']['samples']['EchoTime'], [20.0, 40.0]))
+        assert('dcmmeta_version' in meta)
+        assert('dcmmeta_affine' in meta)
+        assert('dcmmeta_reorient_transform' in meta)
+        assert meta['dcmmeta_shape'] == [192, 192, 2, 2]
+        assert meta['dcmmeta_slice_dim'] ==  2
+        assert meta['global']['const']['Rows'] == 192
+        assert meta['global']['const']['Columns'] == 192
+        assert(np.allclose(meta['time']['samples']['EchoTime'], [20.0, 40.0]))

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -5,7 +5,7 @@ import sys
 from os import path
 from glob import glob
 
-from nose.tools import ok_, eq_, assert_raises
+import pytest
 import numpy as np
 import nibabel as nb
 try:
@@ -18,79 +18,66 @@ from . import test_dir, src_dir
 from dcmstack import dcmmeta
 
 def test_is_constant():
-    ok_(dcmmeta.is_constant([0]))
-    ok_(dcmmeta.is_constant([0, 0]))
-    ok_(dcmmeta.is_constant([0, 0, 1, 1], period=2))
-    ok_(dcmmeta.is_constant([0, 0, 1, 1, 2, 2], period=2))
-    eq_(dcmmeta.is_constant([0, 1]), False)
-    eq_(dcmmeta.is_constant([0, 0, 1, 2], 2), False)
-    assert_raises(ValueError, dcmmeta.is_constant, [0, 0, 0], -1)
-    assert_raises(ValueError, dcmmeta.is_constant, [0, 0, 0], 1)
-    assert_raises(ValueError, dcmmeta.is_constant, [0, 0, 0], 2)
-    assert_raises(ValueError, dcmmeta.is_constant, [0, 0, 0], 4)
+    assert(dcmmeta.is_constant([0]))
+    assert(dcmmeta.is_constant([0, 0]))
+    assert(dcmmeta.is_constant([0, 0, 1, 1], period=2))
+    assert(dcmmeta.is_constant([0, 0, 1, 1, 2, 2], period=2))
+    assert dcmmeta.is_constant([0, 1]) == False
+    assert dcmmeta.is_constant([0, 0, 1, 2], 2) == False
+    with pytest.raises(ValueError):
+        dcmmeta.is_constant([0, 0, 0], -1)
+        dcmmeta.is_constant([0, 0, 0], 1)
+        dcmmeta.is_constant([0, 0, 0], 2)
+        dcmmeta.is_constant([0, 0, 0], 4)
 
 def test_is_repeating():
-    ok_(dcmmeta.is_repeating([0, 1, 0, 1], 2))
-    ok_(dcmmeta.is_repeating([0, 1, 0, 1, 0, 1], 2))
-    eq_(dcmmeta.is_repeating([0, 1, 1, 2], 2), False)
-    assert_raises(ValueError, dcmmeta.is_repeating, [0, 1, 0, 1], -1)
-    assert_raises(ValueError, dcmmeta.is_repeating, [0, 1, 0, 1], 1)
-    assert_raises(ValueError, dcmmeta.is_repeating, [0, 1, 0, 1], 3)
-    assert_raises(ValueError, dcmmeta.is_repeating, [0, 1, 0, 1], 4)
-    assert_raises(ValueError, dcmmeta.is_repeating, [0, 1, 0, 1], 5)
+    assert(dcmmeta.is_repeating([0, 1, 0, 1], 2))
+    assert(dcmmeta.is_repeating([0, 1, 0, 1, 0, 1], 2))
+    assert dcmmeta.is_repeating([0, 1, 1, 2], 2) == False
+    with pytest.raises(ValueError):
+        dcmmeta.is_repeating([0, 1, 0, 1], -1)
+        dcmmeta.is_repeating([0, 1, 0, 1], 1)
+        dcmmeta.is_repeating([0, 1, 0, 1], 3)
+        dcmmeta.is_repeating([0, 1, 0, 1], 4)
+        dcmmeta.is_repeating([0, 1, 0, 1], 5)
 
 def test_get_valid_classes():
     ext = dcmmeta.DcmMetaExtension.make_empty((2, 2, 2), np.eye(4))
-    eq_(ext.get_valid_classes(), (('global', 'const'), ('global', 'slices')))
+    assert ext.get_valid_classes() == (('global', 'const'), ('global', 'slices'))
 
     ext.shape = (2, 2, 2, 2)
-    eq_(ext.get_valid_classes(),
-        (('global', 'const'),
-         ('global', 'slices'),
-         ('time', 'samples'),
-         ('time', 'slices')
-        )
-       )
+    assert ext.get_valid_classes() == (('global', 'const'), ('global', 'slices'), ('time', 'samples'), ('time', 'slices'))
 
     ext.shape = (2, 2, 2, 1, 2)
-    eq_(ext.get_valid_classes(),
-        (('global', 'const'),
-         ('global', 'slices'),
-         ('vector', 'samples'),
-         ('vector', 'slices')
-        )
-       )
+    assert ext.get_valid_classes() == (('global', 'const'), ('global', 'slices'), ('vector', 'samples'), ('vector', 'slices'))
 
     ext.shape = (2, 2, 2, 2, 2)
-    eq_(ext.get_valid_classes(),
-        (('global', 'const'),
-         ('global', 'slices'),
-         ('time', 'samples'),
-         ('time', 'slices'),
-         ('vector', 'samples'),
-         ('vector', 'slices')
-        )
-       )
+    assert ext.get_valid_classes() == (('global', 'const'), \
+                                      ('global', 'slices'), \
+                                      ('time', 'samples'), \
+                                      ('time', 'slices'), \
+                                      ('vector', 'samples'), \
+                                      ('vector', 'slices'))
 
 def test_get_mulitplicity_4d():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 7, 11),
                                               np.eye(4),
                                               np.eye(4),
                                               2)
-    eq_(ext.get_multiplicity(('global', 'const')), 1)
-    eq_(ext.get_multiplicity(('global', 'slices')), 7 * 11)
-    eq_(ext.get_multiplicity(('time', 'samples')), 11)
-    eq_(ext.get_multiplicity(('time', 'slices')), 7)
+    assert ext.get_multiplicity(('global', 'const')) == 1
+    assert ext.get_multiplicity(('global', 'slices')) == 7 * 11
+    assert ext.get_multiplicity(('time', 'samples')) == 11
+    assert ext.get_multiplicity(('time', 'slices')) == 7
 
 def test_get_mulitplicity_4d_vec():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 7, 1, 11),
                                               np.eye(4),
                                               np.eye(4),
                                               2)
-    eq_(ext.get_multiplicity(('global', 'const')), 1)
-    eq_(ext.get_multiplicity(('global', 'slices')), 7 * 11)
-    eq_(ext.get_multiplicity(('vector', 'samples')), 11)
-    eq_(ext.get_multiplicity(('vector', 'slices')), 7)
+    assert ext.get_multiplicity(('global', 'const')) == 1
+    assert ext.get_multiplicity(('global', 'slices')) == 7 * 11
+    assert ext.get_multiplicity(('vector', 'samples')) == 11
+    assert ext.get_multiplicity(('vector', 'slices')) == 7
 
 def test_get_mulitplicity_5d():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 7, 11, 13),
@@ -98,12 +85,12 @@ def test_get_mulitplicity_5d():
                                               np.eye(4),
                                               2
                                              )
-    eq_(ext.get_multiplicity(('global', 'const')), 1)
-    eq_(ext.get_multiplicity(('global', 'slices')), 7 * 11 * 13)
-    eq_(ext.get_multiplicity(('time', 'samples')), 11 * 13)
-    eq_(ext.get_multiplicity(('time', 'slices')), 7)
-    eq_(ext.get_multiplicity(('vector', 'samples')), 13)
-    eq_(ext.get_multiplicity(('vector', 'slices')), 7 * 11)
+    assert ext.get_multiplicity(('global', 'const')) == 1
+    assert ext.get_multiplicity(('global', 'slices')) == 7 * 11 * 13
+    assert ext.get_multiplicity(('time', 'samples')) == 11 * 13
+    assert ext.get_multiplicity(('time', 'slices')) == 7
+    assert ext.get_multiplicity(('vector', 'samples')) == 13
+    assert ext.get_multiplicity(('vector', 'slices')) == 7 * 11
 
 class TestCheckValid(object):
     def setUp(self):
@@ -112,6 +99,9 @@ class TestCheckValid(object):
                                                        np.eye(4),
                                                        2)
 
+    def setup_method(self, setUp):
+        self.setUp()
+
     def test_empty(self):
         self.ext.check_valid()
 
@@ -119,75 +109,93 @@ class TestCheckValid(object):
         self.ext.get_class_dict(('global', 'const'))['ConstTest'] = 2
         self.ext.check_valid()
         del self.ext._content['global']['const']
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_global_slices(self):
         cls_dict = self.ext.get_class_dict(('global', 'slices'))
         cls_dict['SliceTest'] = [0] * 23
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         cls_dict['SliceTest'] = [0] * 24
         self.ext.check_valid()
         del self.ext._content['global']['slices']
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_time_samples(self):
         cls_dict = self.ext.get_class_dict(('time', 'samples'))
         cls_dict['TimeSampleTest'] = [0] * 2
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         cls_dict['TimeSampleTest'] = [0] * 3
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         cls_dict['TimeSampleTest'] = [0] * 12
         self.ext.check_valid()
         del self.ext._content['time']['samples']
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_time_slices(self):
         cls_dict = self.ext.get_class_dict(('time', 'slices'))
         cls_dict['TimeSliceTest'] = [0]
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         cls_dict['TimeSliceTest'] = [0] * 2
         self.ext.check_valid()
         del self.ext._content['time']['slices']
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError): 
+            self.ext.check_valid()
 
     def test_vector_samples(self):
         cls_dict = self.ext.get_class_dict(('vector', 'samples'))
         cls_dict['VectorSampleTest'] = [0] * 3
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         cls_dict['VectorSampleTest'] = [0] * 4
         self.ext.check_valid()
         del self.ext._content['vector']['samples']
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_vector_slices(self):
         cls_dict = self.ext.get_class_dict(('vector', 'slices'))
         cls_dict['VectorSliceTest'] = [0] * 5
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         cls_dict['VectorSliceTest'] = [0] * 6
         self.ext.check_valid()
         del self.ext._content['vector']['slices']
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_invalid_affine(self):
         self.ext._content['dcmmeta_affine'] = np.eye(3).tolist()
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_invalid_slice_dim(self):
         self.ext._content['dcmmeta_slice_dim'] = 3
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         self.ext._content['dcmmeta_slice_dim'] = -1
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_invalid_shape(self):
         self.ext._content['dcmmeta_shape'] = [2, 2]
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
         self.ext._content['dcmmeta_shape'] = [2, 2, 1, 1, 1, 2]
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
     def test_multiple_classes(self):
         self.ext.get_class_dict(('global', 'const'))['Test'] = 0
         self.ext.get_class_dict(('time', 'samples'))['Test'] = [0] * 3
-        assert_raises(dcmmeta.InvalidExtensionError, self.ext.check_valid)
+        with pytest.raises(dcmmeta.InvalidExtensionError):
+            self.ext.check_valid()
 
 def test_dcmmeta_affine():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 2),
@@ -195,63 +203,51 @@ def test_dcmmeta_affine():
                                               np.eye(4),
                                               2
                                              )
-    ok_(np.allclose(ext.affine, np.diag([1, 2, 3, 4])))
-    assert_raises(ValueError,
-                  setattr,
-                  ext,
-                  'affine',
-                  np.eye(3)
-                 )
+    assert(np.allclose(ext.affine, np.diag([1, 2, 3, 4])))
+    with pytest.raises(ValueError):
+        setattr(ext, 'affine', np.eye(3))
     ext.affine = np.eye(4)
-    ok_(np.allclose(ext.affine, np.eye(4)))
+    assert(np.allclose(ext.affine, np.eye(4)))
 
 def test_dcmmeta_slice_dim():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 2), np.eye(4))
-    eq_(ext.slice_dim, None)
-    assert_raises(ValueError,
-                  setattr,
-                  ext,
-                  'slice_dim',
-                  3
-                 )
+    assert ext.slice_dim == None
+    with pytest.raises(ValueError):
+        setattr(ext, 'slice_dim', 3)
     ext.slice_dim = 2
-    eq_(ext.slice_dim, 2)
+    assert ext.slice_dim == 2
 
 def test_dcmmeta_shape():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 2), np.eye(4))
-    eq_(ext.shape, (64, 64, 2))
-    assert_raises(ValueError,
-                  setattr,
-                  ext,
-                  'shape',
-                  (64, 64)
-                 )
+    assert ext.shape == (64, 64, 2)
+    with pytest.raises(ValueError):
+        setattr(ext, 'shape', (64, 64))
     ext.shape = (128, 128, 64)
-    eq_(ext.shape, (128, 128, 64))
+    assert ext.shape == (128, 128, 64)
 
 def test_dcmmeta_version():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 2), np.eye(4))
-    eq_(ext.version, dcmmeta._meta_version)
+    assert ext.version == dcmmeta._meta_version
     ext.version = 1.0
-    eq_(ext.version, 1.0)
+    assert ext.version == 1.0
 
 def test_dcmmeta_slice_norm():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 2),
                                               np.eye(4),
                                               np.eye(4),
                                               2)
-    ok_(np.allclose(ext.slice_normal, [0, 0, 1]))
+    assert(np.allclose(ext.slice_normal, [0, 0, 1]))
     ext.slice_dim = 1
-    ok_(np.allclose(ext.slice_normal, [0, 1, 0]))
+    assert(np.allclose(ext.slice_normal, [0, 1, 0]))
 
 def test_dcmmeta_n_slices():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 2),
                                               np.eye(4),
                                               np.eye(4),
                                               2)
-    eq_(ext.n_slices, 2)
+    assert ext.n_slices == 2
     ext.slice_dim = 1
-    eq_(ext.n_slices, 64)
+    assert ext.n_slices == 64
 
 class TestGetKeysClassesValues(object):
     def setUp(self):
@@ -267,36 +263,35 @@ class TestGetKeysClassesValues(object):
             self.ext.get_class_dict(classes)[key] = \
                 ([0] * self.ext.get_multiplicity(classes))
 
+    def setup_method(self, setUp):
+        self.setUp()
 
     def test_get_keys(self):
-        eq_(set(self.keys), set(self.ext.get_keys()))
+        assert set(self.keys) == set(self.ext.get_keys())
 
     def test_get_classification(self):
-        eq_(self.ext.get_classification('foo'), None)
+        assert self.ext.get_classification('foo') == None
         for classes in self.ext.get_valid_classes():
             key = '%s_%s_test' % classes
-            eq_(self.ext.get_classification(key), classes)
+            assert self.ext.get_classification(key) == classes
 
     def test_get_class_dict(self):
         for classes in self.ext.get_valid_classes():
             key = '%s_%s_test' % classes
-            ok_(key in self.ext.get_class_dict(classes))
+            assert(key in self.ext.get_class_dict(classes))
 
     def test_get_values(self):
-        eq_(self.ext.get_values('foo'), None)
+        assert self.ext.get_values('foo') == None
         for classes in self.ext.get_valid_classes():
             key = '%s_%s_test' % classes
-            eq_(self.ext.get_values(key),
-                [0] * self.ext.get_multiplicity(classes)
-               )
+            assert self.ext.get_values(key) == [0] * self.ext.get_multiplicity(classes)
+               
 
     def test_get_vals_and_class(self):
-        eq_(self.ext.get_values_and_class('foo'), (None, None))
+        assert self.ext.get_values_and_class('foo') == (None, None)
         for classes in self.ext.get_valid_classes():
             key = '%s_%s_test' % classes
-            eq_(self.ext.get_values_and_class(key),
-                ([0] * self.ext.get_multiplicity(classes), classes)
-               )
+            assert(self.ext.get_values_and_class(key) == ([0] * self.ext.get_multiplicity(classes), classes))
 
 class TestFiltering(object):
     def setUp(self):
@@ -313,23 +308,26 @@ class TestFiltering(object):
             self.ext.get_class_dict(classes)[prefix + 'foobaz'] = \
                     ([0] * self.ext.get_multiplicity(classes))
 
+    def setup_method(self, setUp):
+        self.setUp()
+
     def test_filter_all(self):
         self.ext.filter_meta(lambda key, val: 'foo' in key)
-        eq_(len(self.ext.get_keys()), 0)
+        assert len(self.ext.get_keys()) == 0
 
     def test_filter_some(self):
         self.ext.filter_meta(lambda key, val: key.endswith('baz'))
         keys = self.ext.get_keys()
         for classes in self.ext.get_valid_classes():
             prefix = '%s_%s_test_' % classes
-            ok_(prefix + 'foo' in keys)
-            ok_(not prefix + 'foobaz' in keys)
+            assert(prefix + 'foo' in keys)
+            assert(not prefix + 'foobaz' in keys)
 
     def test_clear_slices(self):
         self.ext.clear_slice_meta()
         for base_cls, sub_cls in self.ext.get_valid_classes():
             if sub_cls == 'slices':
-                eq_(len(self.ext.get_class_dict((base_cls, sub_cls))), 0)
+                assert len(self.ext.get_class_dict((base_cls, sub_cls))) == 0
 
 class TestSimplify(object):
     def setUp(self):
@@ -338,6 +336,8 @@ class TestSimplify(object):
                                                        np.eye(4),
                                                        2
                                                       )
+    def setup_method(self, setUp):
+        self.setUp()
 
     def test_simplify_global_slices(self):
         glob_slc = self.ext.get_class_dict(('global', 'slices'))
@@ -356,20 +356,20 @@ class TestSimplify(object):
             glob_slc['Test5'] += [idx2 for idx2 in range(3)]
         self.ext.check_valid()
 
-        eq_(self.ext._simplify('Test1'), True)
-        eq_(self.ext.get_classification('Test1'), ('global', 'const'))
+        assert self.ext._simplify('Test1') == True
+        assert self.ext.get_classification('Test1') == ('global', 'const')
 
-        eq_(self.ext._simplify('Test2'), True)
-        eq_(self.ext.get_classification('Test2'), ('vector', 'samples'))
+        assert self.ext._simplify('Test2') == True
+        assert self.ext.get_classification('Test2'), ('vector', 'samples')
 
-        eq_(self.ext._simplify('Test3'), True)
-        eq_(self.ext.get_classification('Test3'), ('time', 'samples'))
+        assert self.ext._simplify('Test3') == True
+        assert self.ext.get_classification('Test3') == ('time', 'samples')
 
-        eq_(self.ext._simplify('Test4'), True)
-        eq_(self.ext.get_classification('Test4'), ('vector', 'slices'))
+        assert self.ext._simplify('Test4') == True
+        assert self.ext.get_classification('Test4'), ('vector', 'slices')
 
-        eq_(self.ext._simplify('Test5'), True)
-        eq_(self.ext.get_classification('Test5'), ('time', 'slices'))
+        assert self.ext._simplify('Test5') == True
+        assert self.ext.get_classification('Test5'), ('time', 'slices')
 
     def test_simplify_vector_slices(self):
         vec_slc = self.ext.get_class_dict(('vector', 'slices'))
@@ -383,22 +383,22 @@ class TestSimplify(object):
                 vec_slc['Test3'] += [slc_idx]
         self.ext.check_valid()
 
-        eq_(self.ext._simplify('Test1'), True)
-        eq_(self.ext.get_classification('Test1'), ('global', 'const'))
+        assert self.ext._simplify('Test1') ==  True
+        assert self.ext.get_classification('Test1') == ('global', 'const')
 
-        eq_(self.ext._simplify('Test2'), True)
-        eq_(self.ext.get_classification('Test2'), ('time', 'samples'))
+        assert self.ext._simplify('Test2') ==  True
+        assert self.ext.get_classification('Test2') == ('time', 'samples')
 
-        eq_(self.ext._simplify('Test3'), True)
-        eq_(self.ext.get_classification('Test3'), ('time', 'slices'))
+        assert self.ext._simplify('Test3') ==  True
+        assert self.ext.get_classification('Test3') == ('time', 'slices')
 
     def test_simplify_time_slices(self):
         time_slc = self.ext.get_class_dict(('time', 'slices'))
         time_slc['Test1'] = [0] * 3
         self.ext.check_valid()
 
-        eq_(self.ext._simplify('Test1'), True)
-        eq_(self.ext.get_classification('Test1'), ('global', 'const'))
+        assert self.ext._simplify('Test1') == True
+        assert self.ext.get_classification('Test1') == ('global', 'const')
 
     def test_simplify_time_samples(self):
         time_smp = self.ext.get_class_dict(('time', 'samples'))
@@ -408,20 +408,19 @@ class TestSimplify(object):
             time_smp['Test2'] += [vec_idx] * 5
         self.ext.check_valid()
 
-        eq_(self.ext._simplify('Test1'), True)
-        eq_(self.ext.get_values_and_class('Test1'),
-            (0, ('global', 'const')))
+        assert self.ext._simplify('Test1') == True
+        assert self.ext.get_values_and_class('Test1') == (0, ('global', 'const'))
 
-        eq_(self.ext._simplify('Test2'), True)
-        eq_(self.ext.get_classification('Test2'), ('vector', 'samples'))
+        assert self.ext._simplify('Test2') == True
+        assert self.ext.get_classification('Test2') == ('vector', 'samples')
 
     def test_simplify_vector_samples(self):
         vector_smp = self.ext.get_class_dict(('vector', 'samples'))
         vector_smp['Test1'] = [0] * 7
         self.ext.check_valid()
 
-        eq_(self.ext._simplify('Test1'), True)
-        eq_(self.ext.get_classification('Test1'), ('global', 'const'))
+        assert self.ext._simplify('Test1') == True
+        assert self.ext.get_classification('Test1') == ('global', 'const')
 
 def test_simp_sngl_slc_5d():
     ext = dcmmeta.DcmMetaExtension.make_empty((64, 64, 1, 3, 5),
@@ -432,9 +431,7 @@ def test_simp_sngl_slc_5d():
     glob_slc = ext.get_class_dict(('global', 'slices'))
     glob_slc['test1'] = list(range(15))
     ext._simplify('test1')
-    eq_(ext.get_values_and_class('test1'),
-        (list(range(15)), ('time','samples'))
-       )
+    assert ext.get_values_and_class('test1') == (list(range(15)), ('time','samples'))
 
 class TestGetSubset(object):
     def setUp(self):
@@ -450,6 +447,9 @@ class TestGetSubset(object):
             mult = self.ext.get_multiplicity(classes)
             self.ext.get_class_dict(classes)[key] = list(range(mult))
 
+    def setup_method(self, setUp):
+        self.setUp()
+
     def test_slice_subset(self):
         for slc_idx in range(self.ext.n_slices):
             sub = self.ext.get_subset(2, slc_idx)
@@ -458,20 +458,15 @@ class TestGetSubset(object):
             for classes in self.ext.get_valid_classes():
                 key = '%s_%s_test' % classes
                 if classes == ('time', 'slices'):
-                    eq_(sub.get_values_and_class(key),
-                        (slc_idx, ('global', 'const'))
-                       )
+                    assert sub.get_values_and_class(key) ==(slc_idx, ('global', 'const'))
+
                 elif classes == ('vector', 'slices'):
-                    eq_(sub.get_values_and_class(key),
-                        ((list(range(slc_idx, (3 * 5), 3)) * 7), ('time', 'samples'))
-                       )
+                    assert sub.get_values_and_class(key) == ((list(range(slc_idx, (3 * 5), 3)) * 7), ('time', 'samples'))
+
                 elif classes == ('global', 'slices'):
-                    eq_(sub.get_values_and_class(key),
-                        (list(range(slc_idx, (3 * 5 * 7), 3)), ('time', 'samples')))
+                    assert sub.get_values_and_class(key) == (list(range(slc_idx, (3 * 5 * 7), 3)), ('time', 'samples'))
                 else:
-                    eq_(sub.get_values_and_class(key),
-                        self.ext.get_values_and_class(key)
-                       )
+                    assert sub.get_values_and_class(key) == self.ext.get_values_and_class(key)
 
     def test_slice_subset_simplify(self):
         vals = []
@@ -497,10 +492,8 @@ class TestGetSubset(object):
 
         sub = self.ext.get_subset(2, 1)
         sub.check_valid()
-        eq_(sub.get_values_and_class('vec_slc_to_const'),
-            (1, ('global', 'const')))
-        eq_(sub.get_values_and_class('glb_slc_to_const'),
-            (1, ('global', 'const')))
+        assert sub.get_values_and_class('vec_slc_to_const') == (1, ('global', 'const'))
+        assert sub.get_values_and_class('glb_slc_to_const') == (1, ('global', 'const'))
 
     def test_time_sample_subset(self):
         for time_idx in range(5):
@@ -509,37 +502,28 @@ class TestGetSubset(object):
             for classes in self.ext.get_valid_classes():
                 key = '%s_%s_test' % classes
                 if classes[0] == 'time':
-                    ok_(not classes in sub.get_valid_classes())
+                    assert(not classes in sub.get_valid_classes())
                     if classes[1] == 'samples':
-                        eq_(sub.get_values_and_class(key),
-                            (list(range(time_idx, 5 * 7, 5)), ('vector', 'samples'))
-                           )
+                        assert sub.get_values_and_class(key) == (list(range(time_idx, 5 * 7, 5)), ('vector', 'samples'))
                     elif classes[1] == 'slices':
-                        eq_(sub.get_values_and_class(key),
-                            (self.ext.get_values(key), ('vector', 'slices')))
+                        assert sub.get_values_and_class(key) == (self.ext.get_values(key), ('vector', 'slices'))
                 elif classes[0] == 'vector':
                     if classes[1] == 'samples':
-                        eq_(sub.get_values_and_class(key),
-                            self.ext.get_values_and_class(key)
-                           )
+                        assert sub.get_values_and_class(key) == self.ext.get_values_and_class(key)
                     elif classes[1] == 'slices':
                         start = time_idx * 3
                         end = start + 3
-                        eq_(sub.get_values_and_class(key),
-                            (list(range(start, end)), ('vector', 'slices')))
+                        assert sub.get_values_and_class(key) == (list(range(start, end)), ('vector', 'slices'))
                 else:
                     if classes[1] == 'const':
-                        eq_(sub.get_values_and_class(key),
-                            self.ext.get_values_and_class(key)
-                           )
+                        assert sub.get_values_and_class(key) == self.ext.get_values_and_class(key)
                     elif classes[1] == 'slices':
                         vals = []
                         for vec_idx in range(7):
                             start = (vec_idx * (3 * 5)) + (time_idx * 3)
                             end = start + 3
                             vals += list(range(start, end))
-                        eq_(sub.get_values_and_class(key),
-                            (vals, ('global', 'slices')))
+                        assert sub.get_values_and_class(key) == (vals, ('global', 'slices'))
 
     def test_time_sample_subset_simplify(self):
         #Test for simplification of time samples that become constant
@@ -553,8 +537,7 @@ class TestGetSubset(object):
         for time_idx in range(5):
             sub = self.ext.get_subset(3, time_idx)
             sub.check_valid()
-            eq_(sub.get_values_and_class('time_smp_to_const'),
-                (time_idx, ('global', 'const')))
+            assert sub.get_values_and_class('time_smp_to_const') == (time_idx, ('global', 'const'))
 
         #Test for simplification of vector slices that become constant
         vals = []
@@ -581,10 +564,8 @@ class TestGetSubset(object):
 
         sub = self.ext.get_subset(3, 1)
         sub.check_valid()
-        eq_(sub.get_values_and_class('vec_slc_to_const'),
-            (1, ('global', 'const')))
-        eq_(sub.get_values_and_class('glb_slc_to_const'),
-            (1, ('global', 'const')))
+        assert sub.get_values_and_class('vec_slc_to_const') == (1, ('global', 'const'))
+        assert sub.get_values_and_class('glb_slc_to_const') == (1, ('global', 'const'))
 
         #Test simplification of global slices that become vector slices or
         #samples
@@ -603,11 +584,9 @@ class TestGetSubset(object):
             sub = self.ext.get_subset(3, time_idx)
             sub.check_valid()
             if time_idx == 1:
-                eq_(sub.get_values_and_class('glb_slc_to_vec'),
-                    (list(range(3)), ('vector', 'slices')))
+                assert sub.get_values_and_class('glb_slc_to_vec') == (list(range(3)), ('vector', 'slices'))
             else:
-                eq_(sub.get_values_and_class('glb_slc_to_vec'),
-                    (list(range(7)), ('vector', 'samples')))
+                assert sub.get_values_and_class('glb_slc_to_vec') == (list(range(7)), ('vector', 'samples'))
 
     def test_vector_sample_subset(self):
         for vector_idx in range(7):
@@ -616,35 +595,25 @@ class TestGetSubset(object):
             for classes in self.ext.get_valid_classes():
                 key = '%s_%s_test' % classes
                 if classes[0] == 'vector':
-                    ok_(not classes in sub.get_valid_classes())
+                    assert(not classes in sub.get_valid_classes())
                     if classes[1] == 'samples':
-                        eq_(sub.get_values_and_class(key),
-                            (vector_idx, ('global', 'const'))
-                           )
+                        assert sub.get_values_and_class(key) == (vector_idx, ('global', 'const'))
                     elif classes[1] == 'slices':
-                        eq_(sub.get_values_and_class(key),
-                            (list(range(3 * 5)), ('global', 'slices'))
-                           )
+                        assert sub.get_values_and_class(key) == (list(range(3 * 5)), ('global', 'slices'))
                 elif classes[0] == 'time':
                     if classes[1] == 'samples': #Could be const
                         start = vector_idx * 5
                         end = start + 5
-                        eq_(sub.get_values_and_class(key),
-                            (list(range(start, end)), classes)
-                           )
+                        assert sub.get_values_and_class(key) == (list(range(start, end)), classes)
                     elif classes[1] == 'slices':
-                        eq_(sub.get_values_and_class(key),
-                            self.ext.get_values_and_class(key))
+                        assert sub.get_values_and_class(key) == self.ext.get_values_and_class(key)
                 else:
                     if classes[1] == 'const':
-                        eq_(sub.get_values_and_class(key),
-                            self.ext.get_values_and_class(key)
-                           )
+                        assert sub.get_values_and_class(key) == self.ext.get_values_and_class(key)
                     elif classes[1] == 'slices': #Could be const or time samples or time slices
                         start = vector_idx * (3 * 5)
                         end = start + (3 * 5)
-                        eq_(sub.get_values_and_class(key),
-                            (list(range(start, end)), classes))
+                        assert sub.get_values_and_class(key) == (list(range(start, end)), classes)
 
     def test_vector_sample_subset_simplify(self):
 
@@ -659,8 +628,7 @@ class TestGetSubset(object):
         self.ext.get_class_dict(('time', 'samples'))['time_smp_to_const'] = \
             vals
         sub = self.ext.get_subset(4, 1)
-        eq_(sub.get_values_and_class('time_smp_to_const'),
-            (1, ('global', 'const')))
+        assert sub.get_values_and_class('time_smp_to_const') == (1, ('global', 'const'))
 
         #Test for simplification of global slices that become constant, time
         #samples, or time slices
@@ -681,14 +649,11 @@ class TestGetSubset(object):
             sub = self.ext.get_subset(4, vector_idx)
             sub.check_valid()
             if vector_idx == 1:
-                eq_(sub.get_values_and_class('glb_slc'),
-                    (1, ('global', 'const')))
+                assert sub.get_values_and_class('glb_slc') == (1, ('global', 'const'))
             elif vector_idx == 2:
-                eq_(sub.get_values_and_class('glb_slc'),
-                    (list(range(3)), ('time', 'slices')))
+                assert sub.get_values_and_class('glb_slc') == (list(range(3)), ('time', 'slices'))
             else:
-                eq_(sub.get_values_and_class('glb_slc'),
-                    (list(range(5)), ('time', 'samples')))
+                assert sub.get_values_and_class('glb_slc') == (list(range(5)), ('time', 'samples'))
 
 class TestChangeClass(object):
     def setUp(self):
@@ -707,80 +672,55 @@ class TestChangeClass(object):
                 vals = list(range(mult))
             self.ext.get_class_dict(classes)[key] = vals
 
+    def setup_method(self, setUp):
+        self.setUp()
+
     def test_change_none(self):
-        eq_(self.ext._get_changed_class('None_test', ('global', 'const')),
-            None)
-        eq_(self.ext._get_changed_class('None_test', ('global', 'slices')),
-            [None] * (3 * 5 * 7))
-        eq_(self.ext._get_changed_class('None_test', ('time', 'samples')),
-            [None] * (5 * 7))
-        eq_(self.ext._get_changed_class('None_test', ('time', 'slices')),
-            [None] * 3)
-        eq_(self.ext._get_changed_class('None_test', ('vector', 'samples')),
-            [None] * 7)
-        eq_(self.ext._get_changed_class('None_test', ('vector', 'slices')),
-            [None] * (3 * 5))
+        assert self.ext._get_changed_class('None_test', ('global', 'const')) == None
+        assert self.ext._get_changed_class('None_test', ('global', 'slices')) == [None] * (3 * 5 * 7)
+        assert self.ext._get_changed_class('None_test', ('time', 'samples')) ==[None] * (5 * 7)
+        assert self.ext._get_changed_class('None_test', ('time', 'slices')) == [None] * 3
+        assert self.ext._get_changed_class('None_test', ('vector', 'samples')) == [None] * 7
+        assert self.ext._get_changed_class('None_test', ('vector', 'slices')) == [None] * (3 * 5)
 
     def test_change_global_const(self):
-        eq_(self.ext._get_changed_class('global_const_test',
-                                        ('global', 'slices')),
-            [0] * (3 * 5 * 7))
-        eq_(self.ext._get_changed_class('global_const_test',
-                                        ('time', 'samples')),
-            [0] * (5 * 7))
-        eq_(self.ext._get_changed_class('global_const_test',
-                                        ('time', 'slices')),
-            [0] * 3)
-        eq_(self.ext._get_changed_class('global_const_test',
-                                        ('vector', 'samples')),
-            [0] * 7)
-        eq_(self.ext._get_changed_class('global_const_test',
-                                        ('vector', 'slices')),
-            [0] * (3 * 5))
+        assert self.ext._get_changed_class('global_const_test', ('global', 'slices')) == [0] * (3 * 5 * 7)
+        assert self.ext._get_changed_class('global_const_test', ('time', 'samples')) == [0] * (5 * 7)
+        assert self.ext._get_changed_class('global_const_test', ('time', 'slices')) == [0] * 3
+        assert self.ext._get_changed_class('global_const_test', ('vector', 'samples')) == [0] * 7
+        assert self.ext._get_changed_class('global_const_test', ('vector', 'slices')) == [0] * (3 * 5)
 
     def test_change_vector_samples(self):
         vals = []
         for vector_idx in range(7):
             vals += [vector_idx] * 15
-        eq_(self.ext._get_changed_class('vector_samples_test',
-                                        ('global', 'slices')),
-            vals)
+        assert self.ext._get_changed_class('vector_samples_test', ('global', 'slices')) == vals
         vals = []
         for vector_idx in range(7):
             vals += [vector_idx] * 5
-        eq_(self.ext._get_changed_class('vector_samples_test',
-                                        ('time', 'samples')),
-            vals)
+        assert self.ext._get_changed_class('vector_samples_test', ('time', 'samples')) == vals
 
     def test_change_time_samples(self):
         vals = []
         for time_idx in range(5 * 7):
             vals += [time_idx] * 3
-        eq_(self.ext._get_changed_class('time_samples_test',
-                                        ('global', 'slices')),
-            vals)
+        assert self.ext._get_changed_class('time_samples_test', ('global', 'slices')) == vals
 
     def test_time_slices(self):
         vals = []
         for time_idx in range(5 * 7):
             vals += list(range(3))
-        eq_(self.ext._get_changed_class('time_slices_test',
-                                        ('global', 'slices')),
-            vals)
+        assert self.ext._get_changed_class('time_slices_test', ('global', 'slices')) == vals
         vals = []
         for time_idx in range(5):
             vals += list(range(3))
-        eq_(self.ext._get_changed_class('time_slices_test',
-                                        ('vector', 'slices')),
-            vals)
+        assert self.ext._get_changed_class('time_slices_test', ('vector', 'slices')) == vals
 
     def test_vector_slices(self):
         vals = []
         for vector_idx in range(7):
             vals += list(range(15))
-        eq_(self.ext._get_changed_class('vector_slices_test',
-                                        ('global', 'slices')),
-            vals)
+        assert self.ext._get_changed_class('vector_slices_test', ('global', 'slices')) == vals
 
 
 def test_from_sequence_2d_to_3d():
@@ -799,12 +739,9 @@ def test_from_sequence_2d_to_3d():
     ext2.get_class_dict(('global', 'const'))['var'] = 2
 
     merged = dcmmeta.DcmMetaExtension.from_sequence([ext1, ext2], 2)
-    eq_(merged.get_values_and_class('const'),
-        (1, ('global', 'const')))
-    eq_(merged.get_values_and_class('var'),
-        ([1, 2], ('global', 'slices')))
-    eq_(merged.get_values_and_class('missing'),
-        ([1, None], ('global', 'slices')))
+    assert merged.get_values_and_class('const') == (1, ('global', 'const'))
+    assert merged.get_values_and_class('var') == ([1, 2], ('global', 'slices'))
+    assert merged.get_values_and_class('missing') == ([1, None], ('global', 'slices'))
 
 def test_from_sequence_3d_to_4d():
     for dim_name, dim in (('time', 3), ('vector', 4)):
@@ -828,18 +765,12 @@ def test_from_sequence_3d_to_4d():
         ext2.get_class_dict(('global', 'slices'))['global_slices_var'] = [1, 2]
 
         merged = dcmmeta.DcmMetaExtension.from_sequence([ext1, ext2], dim)
-        eq_(merged.get_values_and_class('global_const_const'),
-            (1, ('global', 'const')))
-        eq_(merged.get_values_and_class('global_const_var'),
-            ([1, 2], (dim_name, 'samples')))
-        eq_(merged.get_values_and_class('global_const_missing'),
-            ([1, None], (dim_name, 'samples')))
-        eq_(merged.get_values_and_class('global_slices_const'),
-            ([0, 1], (dim_name, 'slices')))
-        eq_(merged.get_values_and_class('global_slices_var'),
-            ([0, 1, 1, 2], ('global', 'slices')))
-        eq_(merged.get_values_and_class('global_slices_missing'),
-            ([0, 1, None, None], ('global', 'slices')))
+        assert merged.get_values_and_class('global_const_const'), (1, ('global', 'const'))
+        assert merged.get_values_and_class('global_const_var') == ([1, 2], (dim_name, 'samples'))
+        assert merged.get_values_and_class('global_const_missing') == ([1, None], (dim_name, 'samples'))
+        assert merged.get_values_and_class('global_slices_const') == ([0, 1], (dim_name, 'slices'))
+        assert merged.get_values_and_class('global_slices_var') == ([0, 1, 1, 2], ('global', 'slices'))
+        assert merged.get_values_and_class('global_slices_missing') == ([0, 1, None, None], ('global', 'slices'))
 
 def test_from_sequence_4d_time_to_5d():
     ext1 = dcmmeta.DcmMetaExtension.make_empty((2, 2, 2, 2),
@@ -873,30 +804,18 @@ def test_from_sequence_4d_time_to_5d():
     ext2.get_class_dict(('time', 'slices'))['time_slices_var'] = [1, 2]
 
     merged = dcmmeta.DcmMetaExtension.from_sequence([ext1, ext2], 4)
-    eq_(merged.get_values_and_class('global_const_const'),
-        (1, ('global', 'const')))
-    eq_(merged.get_values_and_class('global_const_var'),
-        ([1, 2], ('vector', 'samples')))
-    eq_(merged.get_values_and_class('global_const_missing'),
-        ([1, None], ('vector', 'samples')))
-    eq_(merged.get_values_and_class('global_slices_const'),
-        ([0, 1, 2, 3], ('vector', 'slices')))
-    eq_(merged.get_values_and_class('global_slices_var'),
-        ([0, 1, 2, 3, 1, 2, 3, 4], ('global', 'slices')))
-    eq_(merged.get_values_and_class('global_slices_missing'),
-        ([0, 1, 2, 3, None, None, None, None], ('global', 'slices')))
-    eq_(merged.get_values_and_class('time_samples_const'),
-        ([0, 1, 0, 1], ('time', 'samples')))
-    eq_(merged.get_values_and_class('time_samples_var'),
-        ([0, 1, 1, 2], ('time', 'samples')))
-    eq_(merged.get_values_and_class('time_samples_missing'),
-        ([0, 1, None, None], ('time', 'samples')))
-    eq_(merged.get_values_and_class('time_slices_const'),
-        ([0, 1], ('time', 'slices')))
-    eq_(merged.get_values_and_class('time_slices_var'),
-        ([0, 1, 0, 1, 1, 2, 1, 2], ('global', 'slices')))
-    eq_(merged.get_values_and_class('time_slices_missing'),
-        ([0, 1, 0, 1, None, None, None, None], ('global', 'slices')))
+    assert merged.get_values_and_class('global_const_const') == (1, ('global', 'const'))
+    assert merged.get_values_and_class('global_const_var') == ([1, 2], ('vector', 'samples'))
+    assert merged.get_values_and_class('global_const_missing') == ([1, None], ('vector', 'samples'))
+    assert merged.get_values_and_class('global_slices_const') == ([0, 1, 2, 3], ('vector', 'slices'))
+    assert merged.get_values_and_class('global_slices_var') == ([0, 1, 2, 3, 1, 2, 3, 4], ('global', 'slices'))
+    assert merged.get_values_and_class('global_slices_missing') == ([0, 1, 2, 3, None, None, None, None], ('global', 'slices'))
+    assert merged.get_values_and_class('time_samples_const') == ([0, 1, 0, 1], ('time', 'samples'))
+    assert merged.get_values_and_class('time_samples_var') == ([0, 1, 1, 2], ('time', 'samples'))
+    assert merged.get_values_and_class('time_samples_missing') == ([0, 1, None, None], ('time', 'samples'))
+    assert merged.get_values_and_class('time_slices_const') == ([0, 1], ('time', 'slices'))
+    assert merged.get_values_and_class('time_slices_var') == ([0, 1, 0, 1, 1, 2, 1, 2], ('global', 'slices'))
+    assert merged.get_values_and_class('time_slices_missing') == ([0, 1, 0, 1, None, None, None, None], ('global', 'slices'))
 
 def test_from_sequence_no_slc():
     ext1 = dcmmeta.DcmMetaExtension.make_empty((2, 2, 2), np.eye(4))
@@ -905,19 +824,18 @@ def test_from_sequence_no_slc():
 
 def test_nifti_wrapper_init():
     nii = nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4))
-    assert_raises(dcmmeta.MissingExtensionError,
-                  dcmmeta.NiftiWrapper,
-                  nii)
+    with pytest.raises(dcmmeta.MissingExtensionError):
+        dcmmeta.NiftiWrapper(nii)
     hdr = nii.header
     ext = dcmmeta.DcmMetaExtension.make_empty((5, 5, 5), np.eye(4))
     hdr.extensions.append(ext)
     nw = dcmmeta.NiftiWrapper(nii)
-    eq_(nw.meta_ext, ext)
+    assert nw.meta_ext == ext
 
     nii2 = nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4))
     nw2 = dcmmeta.NiftiWrapper(nii, True)
     ext2 = nw2.meta_ext
-    eq_(ext, ext2)
+    assert ext == ext2
 
 class TestMetaValid(object):
     def setUp(self):
@@ -926,7 +844,10 @@ class TestMetaValid(object):
         hdr.set_dim_info(None, None, 2)
         self.nw = dcmmeta.NiftiWrapper(nii, True)
         for classes in self.nw.meta_ext.get_valid_classes():
-            ok_(self.nw.meta_valid(classes))
+            assert(self.nw.meta_valid(classes))
+
+    def setup_method(self, setUp):
+        self.setUp()
 
     def test_time_samples_changed(self):
         self.nw.meta_ext.shape = (5, 5, 5, 3, 9)
@@ -934,9 +855,9 @@ class TestMetaValid(object):
             if classes in (('time', 'samples'),
                            ('vector', 'slices'),
                            ('global', 'slices')):
-                eq_(self.nw.meta_valid(classes), False)
+                assert self.nw.meta_valid(classes) == False
             else:
-                ok_(self.nw.meta_valid(classes))
+                assert(self.nw.meta_valid(classes))
 
     def test_vector_samples_changed(self):
         self.nw.meta_ext.shape = (5, 5, 5, 7, 3)
@@ -944,17 +865,17 @@ class TestMetaValid(object):
             if classes in (('time', 'samples'),
                            ('vector', 'samples'),
                            ('global', 'slices')):
-                eq_(self.nw.meta_valid(classes), False)
+                assert self.nw.meta_valid(classes) == False
             else:
-                ok_(self.nw.meta_valid(classes))
+                assert(self.nw.meta_valid(classes))
 
     def test_slice_dim_changed(self):
         self.nw.meta_ext.slice_dim = 0
         for classes in self.nw.meta_ext.get_valid_classes():
             if classes[1] == 'slices':
-                eq_(self.nw.meta_valid(classes), False)
+                assert self.nw.meta_valid(classes) == False
             else:
-                ok_(self.nw.meta_valid(classes))
+                assert(self.nw.meta_valid(classes))
 
     def test_slice_dir_changed(self):
         aff = self.nw.nii_img.affine
@@ -966,9 +887,9 @@ class TestMetaValid(object):
 
         for classes in self.nw.meta_ext.get_valid_classes():
             if classes[1] == 'slices':
-                eq_(self.nw.meta_valid(classes), False)
+                assert self.nw.meta_valid(classes) == False
             else:
-                ok_(self.nw.meta_valid(classes))
+                assert(self.nw.meta_valid(classes))
 
 class TestGetMeta(object):
     def setUp(self):
@@ -987,89 +908,67 @@ class TestGetMeta(object):
                 vals = list(range(mult))
             self.nw.meta_ext.get_class_dict(classes)[key] = vals
 
-    def test_invalid_index(self):
-        assert_raises(IndexError,
-                      self.nw.get_meta('time_samples_test'),
-                      (0, 0, 0, 0))
-        assert_raises(IndexError,
-                      self.nw.get_meta('time_samples_test'),
-                      (0, 0, 0, 0, 0, 0))
-        assert_raises(IndexError,
-                      self.nw.get_meta('time_samples_test'),
-                      (6, 0, 0, 0, 0))
-        assert_raises(IndexError,
-                      self.nw.get_meta('time_samples_test'),
-                      (-1, 0, 0, 0, 0))
+    def setup_method(self, setUp):
+        self.setUp()
 
     def test_get_item(self):
         for classes in self.nw.meta_ext.get_valid_classes():
             key = '%s_%s_test' % classes
             if classes == ('global', 'const'):
-                eq_(self.nw[key], 0)
+                assert self.nw[key] == 0
             else:
-                assert_raises(KeyError,
-                              self.nw.__getitem__,
-                              key)
+                with pytest.raises(KeyError):
+                    self.nw.__getitem__(key)
 
     def test_get_const(self):
-        eq_(self.nw.get_meta('global_const_test'), 0)
-        eq_(self.nw.get_meta('global_const_test', (0, 0, 0, 0, 0)), 0)
-        eq_(self.nw.get_meta('global_const_test', (0, 0, 3, 4, 5)), 0)
+        assert self.nw.get_meta('global_const_test') == 0
+        assert self.nw.get_meta('global_const_test', (0, 0, 0, 0, 0)) == 0
+        assert self.nw.get_meta('global_const_test', (0, 0, 3, 4, 5)) == 0
 
     def test_get_global_slices(self):
-        eq_(self.nw.get_meta('global_slices_test'), None)
-        eq_(self.nw.get_meta('global_slices_test', None, 0), 0)
+        assert self.nw.get_meta('global_slices_test') == None
+        assert self.nw.get_meta('global_slices_test', None, 0) == 0
         for vector_idx in range(9):
             for time_idx in range(7):
                 for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
-                    eq_(self.nw.get_meta('global_slices_test', idx),
-                        slice_idx + (time_idx * 5) + (vector_idx * 7 * 5)
-                       )
+                    assert self.nw.get_meta('global_slices_test', idx) == slice_idx + (time_idx * 5) + (vector_idx * 7 * 5)
 
     def test_get_vector_slices(self):
-        eq_(self.nw.get_meta('vector_slices_test'), None)
-        eq_(self.nw.get_meta('vector_slices_test', None, 0), 0)
+        assert self.nw.get_meta('vector_slices_test') == None
+        assert self.nw.get_meta('vector_slices_test', None, 0) == 0
         for vector_idx in range(9):
             for time_idx in range(7):
                 for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
-                    eq_(self.nw.get_meta('vector_slices_test', idx),
-                        slice_idx + (time_idx * 5)
-                       )
+                    assert self.nw.get_meta('vector_slices_test', idx) == slice_idx + (time_idx * 5)
 
     def test_get_time_slices(self):
-        eq_(self.nw.get_meta('time_slices_test'), None)
-        eq_(self.nw.get_meta('time_slices_test', None, 0), 0)
+        assert self.nw.get_meta('time_slices_test') == None
+        assert self.nw.get_meta('time_slices_test', None, 0) == 0
         for vector_idx in range(9):
             for time_idx in range(7):
                 for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
-                    eq_(self.nw.get_meta('time_slices_test', idx),
-                        slice_idx
-                       )
+                    assert self.nw.get_meta('time_slices_test', idx) == slice_idx
 
     def test_get_vector_samples(self):
-        eq_(self.nw.get_meta('vector_samples_test'), None)
-        eq_(self.nw.get_meta('vector_samples_test', None, 0), 0)
+        assert self.nw.get_meta('vector_samples_test') == None
+        assert self.nw.get_meta('vector_samples_test', None, 0) == 0
         for vector_idx in range(9):
             for time_idx in range(7):
                 for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
-                    eq_(self.nw.get_meta('vector_samples_test', idx),
-                        vector_idx
-                       )
+                    assert self.nw.get_meta('vector_samples_test', idx) == vector_idx
 
     def get_time_samples(self):
-        eq_(self.nw.get_meta('time_samples_test'), None)
-        eq_(self.nw.get_meta('time_samples_test', None, 0), 0)
+        assert self.nw.get_meta('time_samples_test') == None
+        assert self.nw.get_meta('time_samples_test', None, 0) == 0
         for vector_idx in range(9):
             for time_idx in range(7):
                 for slice_idx in range(5):
                     idx = (0, 0, slice_idx, time_idx, vector_idx)
-                    eq_(self.nw.get_meta('time_samples_test', idx),
-                        time_idx + (vector_idx * 7)
-                       )
+                    assert self.nw.get_meta('time_samples_test', idx) == time_idx + (vector_idx * 7)
 
 class TestSplit(object):
     def setUp(self):
@@ -1089,10 +988,13 @@ class TestSplit(object):
                 vals = list(range(mult))
             self.nw.meta_ext.get_class_dict(classes)[key] = vals
 
+    def setup_method(self, setUp):
+        self.setUp()
+
     def test_split_slice(self):
         for split_idx, nw_split in enumerate(self.nw.split(2)):
-            eq_(nw_split.nii_img.shape, (3, 3, 1, 5, 7))
-            ok_(np.allclose(nw_split.nii_img.affine,
+            assert nw_split.nii_img.shape == (3, 3, 1, 5, 7)
+            assert(np.allclose(nw_split.nii_img.affine,
                             np.c_[[1.1, 0.0, 0.0, 0.0],
                                   [0.0, 1.1, 0.0, 0.0],
                                   [0.0, 0.0, 1.1, 0.0],
@@ -1100,25 +1002,25 @@ class TestSplit(object):
                                  ]
                            )
                )
-            ok_(np.all(nw_split.nii_img.get_data() ==
+            assert(np.all(nw_split.nii_img.get_data() ==
                        self.arr[:, :, split_idx:split_idx+1, :, :])
                )
 
     def test_split_time(self):
         for split_idx, nw_split in enumerate(self.nw.split(3)):
-            eq_(nw_split.nii_img.shape, (3, 3, 3, 1, 7))
-            ok_(np.allclose(nw_split.nii_img.affine,
+            assert nw_split.nii_img.shape == (3, 3, 3, 1, 7)
+            assert(np.allclose(nw_split.nii_img.affine,
                             np.diag([1.1, 1.1, 1.1, 1.0])))
-            ok_(np.all(nw_split.nii_img.get_data() ==
+            assert(np.all(nw_split.nii_img.get_data() ==
                        self.arr[:, :, :, split_idx:split_idx+1, :])
                )
 
     def test_split_vector(self):
         for split_idx, nw_split in enumerate(self.nw.split(4)):
-            eq_(nw_split.nii_img.shape, (3, 3, 3, 5))
-            ok_(np.allclose(nw_split.nii_img.affine,
+            assert nw_split.nii_img.shape == (3, 3, 3, 5)
+            assert(np.allclose(nw_split.nii_img.affine,
                             np.diag([1.1, 1.1, 1.1, 1.0])))
-            ok_(np.all(nw_split.nii_img.get_data() ==
+            assert(np.all(nw_split.nii_img.get_data() ==
                        self.arr[:, :, :, :, split_idx])
                )
 
@@ -1128,7 +1030,7 @@ def test_split_keep_spatial():
     nw = dcmmeta.NiftiWrapper(nii, True)
 
     for split_idx, nw_split in enumerate(nw.split(2)):
-        eq_(nw_split.nii_img.shape, (3, 3, 1))
+        assert nw_split.nii_img.shape == (3, 3, 1)
 
 
 def test_from_dicom():
@@ -1142,15 +1044,13 @@ def test_from_dicom():
     meta = {'EchoTime': 40}
     nw = dcmmeta.NiftiWrapper.from_dicom(src_dcm, meta)
     hdr = nw.nii_img.header
-    eq_(nw.nii_img.shape, (192, 192, 1))
-    ok_(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.get_affine()),
+    assert nw.nii_img.shape == (192, 192, 1)
+    assert(np.allclose(np.dot(np.diag([-1., -1., 1., 1.]), src_dw.get_affine()),
                     nw.nii_img.affine)
        )
-    eq_(hdr.get_xyzt_units(), ('mm', 'sec'))
-    eq_(hdr.get_dim_info(), (0, 1, 2))
-    eq_(nw.meta_ext.get_values_and_class('EchoTime'),
-        (40, ('global', 'const'))
-       )
+    assert hdr.get_xyzt_units() == ('mm', 'sec')
+    assert hdr.get_dim_info() == (0, 1, 2)
+    assert nw.meta_ext.get_values_and_class('EchoTime') == (40, ('global', 'const'))
 
 def test_from_2d_slice_to_3d():
     slice_nws = []
@@ -1168,22 +1068,18 @@ def test_from_2d_slice_to_3d():
         slice_nws.append(nw)
 
     merged = dcmmeta.NiftiWrapper.from_sequence(slice_nws, 2)
-    eq_(merged.nii_img.shape, (4, 4, 3))
-    ok_(np.allclose(merged.nii_img.affine,
+    assert merged.nii_img.shape == (4, 4, 3)
+    assert(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 0.5, 1.0)))
        )
-    eq_(merged.meta_ext.get_values_and_class('EchoTime'),
-        (40, ('global', 'const'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('SliceLocation'),
-        (list(range(3)), ('global', 'slices'))
-       )
+    assert merged.meta_ext.get_values_and_class('EchoTime') == (40, ('global', 'const'))
+    assert merged.meta_ext.get_values_and_class('SliceLocation') == (list(range(3)), ('global', 'slices'))
     merged_hdr = merged.nii_img.header
-    eq_(merged_hdr.get_dim_info(), (0, 1, 2))
-    eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
+    assert merged_hdr.get_dim_info() == (0, 1, 2)
+    assert merged_hdr.get_xyzt_units() == ('mm', 'sec')
     merged_data = merged.nii_img.get_data()
     for idx in range(3):
-        ok_(np.all(merged_data[:, :, idx] ==
+        assert(np.all(merged_data[:, :, idx] ==
                    np.arange(idx * (4 * 4), (idx + 1) * (4 * 4)).reshape(4, 4))
            )
 
@@ -1207,28 +1103,20 @@ def test_from_3d_time_to_4d():
         time_nws.append(nw)
 
     merged = dcmmeta.NiftiWrapper.from_sequence(time_nws, 3)
-    eq_(merged.nii_img.shape, (4, 4, 4, 3))
-    ok_(np.allclose(merged.nii_img.affine,
+    assert merged.nii_img.shape == (4, 4, 4, 3)
+    assert(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 1.1, 1.0)))
        )
-    eq_(merged.meta_ext.get_values_and_class('PatientID'),
-        ('Test', ('global', 'const'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('EchoTime'),
-        ([0, 1, 2], ('time', 'samples'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('SliceLocation'),
-        (list(range(4)), ('time', 'slices'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('AcquisitionTime'),
-        (list(range(4 * 3)), ('global', 'slices'))
-       )
+    assert merged.meta_ext.get_values_and_class('PatientID') == ('Test', ('global', 'const'))
+    assert merged.meta_ext.get_values_and_class('EchoTime') == ([0, 1, 2], ('time', 'samples'))
+    assert merged.meta_ext.get_values_and_class('SliceLocation') == (list(range(4)), ('time', 'slices'))
+    assert merged.meta_ext.get_values_and_class('AcquisitionTime') == (list(range(4 * 3)), ('global', 'slices'))
     merged_hdr = merged.nii_img.header
-    eq_(merged_hdr.get_dim_info(), (0, 1, 2))
-    eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
+    assert merged_hdr.get_dim_info() == (0, 1, 2)
+    assert merged_hdr.get_xyzt_units() == ('mm', 'sec')
     merged_data = merged.nii_img.get_data()
     for idx in range(3):
-        ok_(np.all(merged_data[:, :, :, idx] ==
+        assert(np.all(merged_data[:, :, :, idx] ==
                    np.arange(idx * (4 * 4 * 4),
                              (idx + 1) * (4 * 4 * 4)).reshape(4, 4, 4))
            )
@@ -1253,28 +1141,20 @@ def test_from_3d_vector_to_4d():
         vector_nws.append(nw)
 
     merged = dcmmeta.NiftiWrapper.from_sequence(vector_nws, 4)
-    eq_(merged.nii_img.shape, (4, 4, 4, 1, 3))
-    ok_(np.allclose(merged.nii_img.affine,
+    assert merged.nii_img.shape == (4, 4, 4, 1, 3)
+    assert(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 1.1, 1.0)))
        )
-    eq_(merged.meta_ext.get_values_and_class('PatientID'),
-        ('Test', ('global', 'const'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('EchoTime'),
-        ([0, 1, 2], ('vector', 'samples'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('SliceLocation'),
-        (list(range(4)), ('vector', 'slices'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('AcquisitionTime'),
-        (list(range(4 * 3)), ('global', 'slices'))
-       )
+    assert merged.meta_ext.get_values_and_class('PatientID') == ('Test', ('global', 'const'))
+    assert merged.meta_ext.get_values_and_class('EchoTime') == ([0, 1, 2], ('vector', 'samples'))
+    assert merged.meta_ext.get_values_and_class('SliceLocation') == (list(range(4)), ('vector', 'slices'))
+    assert merged.meta_ext.get_values_and_class('AcquisitionTime') == (list(range(4 * 3)), ('global', 'slices'))
     merged_hdr = merged.nii_img.header
-    eq_(merged_hdr.get_dim_info(), (0, 1, 2))
-    eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
+    assert merged_hdr.get_dim_info() == (0, 1, 2)
+    assert merged_hdr.get_xyzt_units(), ('mm', 'sec')
     merged_data = merged.nii_img.get_data()
     for idx in range(3):
-        ok_(np.all(merged_data[:, :, :, 0, idx] ==
+        assert(np.all(merged_data[:, :, :, 0, idx] ==
                    np.arange(idx * (4 * 4 * 4),
                              (idx + 1) * (4 * 4 * 4)).reshape(4, 4, 4))
            )
@@ -1300,8 +1180,8 @@ def test_merge_inconsistent_hdr():
 
     merged = dcmmeta.NiftiWrapper.from_sequence(time_nws)
     merged_hdr = merged.nii_img.header
-    eq_(merged_hdr.get_dim_info(), (None, None, 2))
-    eq_(merged_hdr.get_xyzt_units(), ('mm', 'unknown'))
+    assert merged_hdr.get_dim_info() == (None, None, 2)
+    assert merged_hdr.get_xyzt_units(), ('mm', 'unknown')
 
 def test_merge_with_slc_and_without():
     #Test merging two data sets where one has per slice meta and other does not
@@ -1325,18 +1205,12 @@ def test_merge_with_slc_and_without():
         input_nws.append(nw)
 
     merged = dcmmeta.NiftiWrapper.from_sequence(input_nws)
-    eq_(merged.nii_img.shape, (4, 4, 4, 3))
-    ok_(np.allclose(merged.nii_img.affine,
+    assert merged.nii_img.shape == (4, 4, 4, 3)
+    assert(np.allclose(merged.nii_img.affine,
                     np.diag((1.1, 1.1, 1.1, 1.0)))
        )
-    eq_(merged.meta_ext.get_values_and_class('PatientID'),
-        ('Test', ('global', 'const'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('EchoTime'),
-        ([0, 1, 2], ('time', 'samples'))
-       )
-    eq_(merged.meta_ext.get_values_and_class('SliceLocation'),
-        (list(range(4)) + ([None] * 8), ('global', 'slices'))
-       )
+    assert merged.meta_ext.get_values_and_class('PatientID') == ('Test', ('global', 'const'))
+    assert merged.meta_ext.get_values_and_class('EchoTime') == ([0, 1, 2], ('time', 'samples'))
+    assert merged.meta_ext.get_values_and_class('SliceLocation') == (list(range(4)) + ([None] * 8), ('global', 'slices'))
     merged_hdr = merged.nii_img.header
-    eq_(merged_hdr.get_xyzt_units(), ('mm', 'sec'))
+    assert merged_hdr.get_xyzt_units() == ('mm', 'sec')

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -4,7 +4,7 @@ Tests for dcmstack.extract
 import sys, warnings
 from os import path
 
-from nose.tools import ok_, eq_, assert_raises
+import pytest
 from nibabel.nicom import csareader
 try:
     import pydicom
@@ -18,65 +18,61 @@ with warnings.catch_warnings():
     from dcmstack import extract
 
 class TestCsa(object):
-    def setUp(self):
+    def setup_method(self, method):
         data_fn = path.join(test_dir, 'data', 'extract', 'csa_test.dcm')
         self.data = pydicom.read_file(data_fn)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         del self.data
 
     def test_simplify(self):
-        eq_(extract.simplify_csa_dict(None), None)
+        assert extract.simplify_csa_dict(None) == None
         csa_dict = csareader.read(self.data[pydicom.tag.Tag(0x29, 0x1010)].value)
         simp_dict = extract.simplify_csa_dict(csa_dict)
         for tag in csa_dict['tags']:
             items = csa_dict['tags'][tag]['items']
             if len(items) == 0:
-                ok_(not tag in simp_dict)
+                assert(not tag in simp_dict)
             elif len(items) == 1:
-                eq_(simp_dict[tag], items[0])
+                assert simp_dict[tag] == items[0]
             else:
-                eq_(simp_dict[tag], items)
+                assert simp_dict[tag] == items
 
     def test_csa_image_trans(self):
         csa_dict = extract.csa_series_trans_func(self.data[(0x29, 0x1010)])
-        eq_(csa_dict["EchoLinePosition"], 64)
+        assert csa_dict["EchoLinePosition"] == 64
 
     def test_parse_phx_line(self):
-        ok_(extract._parse_phoenix_line("") is None)
-        ok_(extract._parse_phoenix_line("#test = 2") is None)
+        assert(extract._parse_phoenix_line("") is None)
+        assert(extract._parse_phoenix_line("#test = 2") is None)
 
-        eq_(extract._parse_phoenix_line('test = "" 2 ""'), ('test', ' 2 '))
-        eq_(extract._parse_phoenix_line('test = "" #2 ""'), ('test', ' #2 '))
-        eq_(extract._parse_phoenix_line('test = "" 2 ""#='),
-            ('test', ' 2 '))
-        eq_(extract._parse_phoenix_line("test = 2#"), ('test', 2))
-        eq_(extract._parse_phoenix_line("test = 0x2"), ('test', 2))
-        eq_(extract._parse_phoenix_line("test = 2."), ('test', 2.0))
+        assert extract._parse_phoenix_line('test = "" 2 ""') == ('test', ' 2 ')
+        assert extract._parse_phoenix_line('test = "" #2 ""'), ('test', ' #2 ')
+        assert extract._parse_phoenix_line('test = "" 2 ""#=') == ('test', ' 2 ')
+        assert extract._parse_phoenix_line("test = 2#") == ('test', 2)
+        assert extract._parse_phoenix_line("test = 0x2") == ('test', 2)
+        assert extract._parse_phoenix_line("test = 2.") == ('test', 2.0)
 
-        assert_raises(extract.PhoenixParseError,
-                      extract._parse_phoenix_line,
-                      'test = blah')
-        assert_raises(extract.PhoenixParseError,
-                      extract._parse_phoenix_line,
-                      '==')
-        assert_raises(extract.PhoenixParseError,
-                      extract._parse_phoenix_line,
-                      'test')
-        assert_raises(extract.PhoenixParseError,
-                      extract._parse_phoenix_line,
-                      'test = "" 2 ""3')
+        
+        with pytest.raises(extract.PhoenixParseError):
+            extract._parse_phoenix_line('test = blah')
+        with pytest.raises(extract.PhoenixParseError):
+            extract._parse_phoenix_line('==')
+        with pytest.raises(extract.PhoenixParseError):
+            extract._parse_phoenix_line('test')
+        with pytest.raises(extract.PhoenixParseError):
+            extract._parse_phoenix_line('test = "" 2 ""3')
 
     def test_csa_series_trans(self):
         csa_dict = extract.csa_series_trans_func(self.data[(0x29, 0x1020)])
-        eq_(csa_dict['MrPhoenixProtocol.sEFISPEC.bEFIDataValid'], 1)
+        assert csa_dict['MrPhoenixProtocol.sEFISPEC.bEFIDataValid'] == 1
 
 class TestMetaExtractor(object):
-    def setUp(self):
+    def setup_method(self, method):
         data_fn = path.join(test_dir, 'data', 'extract', 'csa_test.dcm')
         self.data = pydicom.read_file(data_fn)
 
-    def tearDown(self):
+    def teardown_method(self,method):
         del self.data
 
     def test_get_elem_key(self):
@@ -84,9 +80,9 @@ class TestMetaExtractor(object):
         extractor = extract.MetaExtractor(ignore_rules=ignore_rules)
         for elem in self.data:
             key = extractor._get_elem_key(elem)
-            ok_(key.strip() != '')
-            ok_(key[0].isalpha())
-            ok_(key[-1].isalnum())
+            assert(key.strip() != '')
+            assert(key[0].isalpha())
+            assert(key[-1].isalnum())
 
     def test_get_elem_value(self):
         ignore_rules = (extract.ignore_pixel_data,)
@@ -94,17 +90,18 @@ class TestMetaExtractor(object):
         for elem in self.data:
             value = extractor._get_elem_value(elem)
             if elem.VM > 1:
-                ok_(isinstance(value, list))
+                assert(isinstance(value, list))
             if elem.VR in list(extract.unpack_vr_map) + ['DS', 'IS']:
                 if elem.VM == 1:
-                    ok_(not isinstance(value, str))
+                    assert(not isinstance(value, str))
                 else:
-                    ok_(not any(isinstance(val, str) for val in value))
+                    assert(not any(isinstance(val, str) for val in value))
 
     def test_dup_trans(self):
         translators = [extract.csa_image_trans, extract.csa_image_trans]
         extractor = extract.MetaExtractor(translators=translators)
-        assert_raises(ValueError, extractor, self.data)
+        with pytest.raises(ValueError):
+            extractor(self.data)
 
     def test_reloc_private(self):
         extractor = extract.MetaExtractor()
@@ -112,11 +109,11 @@ class TestMetaExtractor(object):
         self.data[(0x29, 0x1010)].tag = pydicom.tag.Tag((0x29, 0x2010))
         self.data[(0x29, 0x1020)].tag = pydicom.tag.Tag((0x29, 0x2020))
         meta_dict = extractor(self.data)
-        eq_(meta_dict["CsaImage.EchoLinePosition"], 64)
-        ok_(meta_dict['CsaSeries.MrPhoenixProtocol.sEFISPEC.bEFIDataValid'], 1)
+        assert meta_dict["CsaImage.EchoLinePosition"] == 64
+        assert(meta_dict['CsaSeries.MrPhoenixProtocol.sEFISPEC.bEFIDataValid'], 1)
 
     def test_non_reloc_private(self):
         extractor = extract.MetaExtractor()
         meta_dict = extractor(self.data)
-        eq_(meta_dict["CsaImage.EchoLinePosition"], 64)
-        ok_(meta_dict['CsaSeries.MrPhoenixProtocol.sEFISPEC.bEFIDataValid'], 1)
+        assert meta_dict["CsaImage.EchoLinePosition"] == 64
+        assert(meta_dict['CsaSeries.MrPhoenixProtocol.sEFISPEC.bEFIDataValid'], 1)


### PR DESCRIPTION
From https://salsa.debian.org/med-team/dcmstack/-/raw/master/debian/patches/port-to-pytest.patch brought up by @tillea in https://github.com/moloney/dcmstack/issues/67#issuecomment-967800718 . In the 2nd commit I also established `setup.cfg` so someone could do `pip install -e .[test]` or alike to get test depends.

Unfortunately it seems that dcmstack is not entirely kosher with most recent numpy and/or python since:

```
FAILED test/test_dcmmeta.py::TestSplit::test_split_slice - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::TestSplit::test_split_time - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::TestSplit::test_split_vector - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::test_split_keep_spatial - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::test_from_dicom - nibabel.deprecator.ExpiredDeprecationError: get_affine method is deprecated.
FAILED test/test_dcmmeta.py::test_from_2d_slice_to_3d - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::test_from_3d_time_to_4d - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::test_from_3d_vector_to_4d - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::test_merge_inconsistent_hdr - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
FAILED test/test_dcmmeta.py::test_merge_with_slc_and_without - IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
```
and that is numpy 1.23.2 and python 3.10.6.  I have not had a chance to try anything else yet.

Closes #67 .