### PR TITLE
Skip conversion on None type

### DIFF
--- a/src/dcmstack/extract.py
+++ b/src/dcmstack/extract.py
@@ -416,7 +416,7 @@ class MetaExtractor(object):
                 value = elem.value
 
         #Handle any conversions
-        if elem.VR in self.conversions:
+        if elem.VR in self.conversions and value is not None:
             if n_vals == 1:
                 value = self.conversions[elem.VR](value)
             else:


### PR DESCRIPTION
Hi,
when using dcmstack with [this Dataset](https://www.ircad.fr/research/data-sets/liver-segmentation-3d-ircadb-01/), there seem to be fields in the DICOM header which have a VR set, but contain no actual value. The conversion step then fails because we cannot iterate over a None value.
I'm not experienced in this area, but this PR would be my approach to fixing it.