### PR TITLE
t/test_cli.py: port setup/teardown to pytest 8.

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -43,10 +43,10 @@ def make_niftis(out_dir, extra_args=tuple()):
 
 
 class CliTest(object):
-    def setup(self):
+    def setup_method(self):
         self.out_dir = mkdtemp(prefix='dcmstack_cli_test_out')
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self.out_dir)
 
 


### PR DESCRIPTION
As pointed out in [Debian bugs #1063943] and [then #1071794], test/test_cli.py fails with pytest 8 and beyon with the following symptoms:

	__________________________ TestDcmstackCli.test_basic __________________________

	self = <test.test_cli.TestDcmstackCli object at 0x7f2d3a00eb40>

	    def test_basic(self):
	>       nii_paths = make_niftis(self.out_dir)
	E       AttributeError: 'TestDcmstackCli' object has no attribute 'out_dir'

	test/test_cli.py:55: AttributeError
	__________________________ TestDcmstackCli.test_embed __________________________

	self = <test.test_cli.TestDcmstackCli object at 0x7f2d3c976180>

	    def test_embed(self):
	>       nii_paths = make_niftis(self.out_dir, ['--embed'])
	E       AttributeError: 'TestDcmstackCli' object has no attribute 'out_dir'

	test/test_cli.py:59: AttributeError
	___________________________ TestNitoolCli.test_basic ___________________________

	self = <test.test_cli.TestNitoolCli object at 0x7f2d39f5b1d0>

	    def test_basic(self):
	>       nii_path = make_niftis(self.out_dir, ['--embed'])[0]
	E       AttributeError: 'TestNitoolCli' object has no attribute 'out_dir'

	test/test_cli.py:65: AttributeError

This is because pytest 8 deprecated the use of plain _setup_ and _teardown_, which were compatibility layers to ease the porting effort from Nose.  This change ensures methods inheriting from CliTest get set up and teared down properly.

[Debian bugs #1063943]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1063943
[then #1071794]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1071794