### PR TITLE
prefer newer unittest.mock from standard library

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,10 @@
 import sys, os
 
 #Mock unavailable packages for ReadTheDocs
-import mock
+try:
+    from unitttest import mock
+except ImportError:
+    import mock
  
 MOCK_MODULES = ['numpy', 
                 'nibabel',


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.
