### PR TITLE
RF: replace pydicom.read_file with dcmread which was added in pydicom 1.0.0

### DIFF
--- a/src/dcmstack/dcmstack.py
+++ b/src/dcmstack/dcmstack.py
@@ -1046,7 +1046,7 @@ def parse_and_group(src_paths, group_by=default_group_keys, extractor=None,
     for dcm_path in src_paths:
         #Read the DICOM file
         try:
-            dcm = pydicom.read_file(dcm_path, force=force)
+            dcm = pydicom.dcmread(dcm_path, force=force)
         except Exception as e:
             if warn_on_except:
                 warnings.warn('Error reading file %s: %s' % (dcm_path, str(e)))

--- a/src/dcmstack/info.py
+++ b/src/dcmstack/info.py
@@ -23,7 +23,7 @@ CLASSIFIERS = ["Development Status :: 3 - Alpha",
 description = 'Stack DICOM images into volumes and convert to Nifti'
 
 # Hard dependencies
-install_requires = ['pydicom >= 0.9.7',
+install_requires = ['pydicom >= 1.0.0',
                     'nibabel >= 2.5.1',
                     'pylibjpeg-libjpeg ; python_version >= "3.7"',
                    ]

--- a/test/test_dcmmeta.py
+++ b/test/test_dcmmeta.py
@@ -1039,7 +1039,7 @@ def test_from_dicom():
                          'dcmstack',
                          '2D_16Echo_qT2')
     src_fn = path.join(data_dir, 'TE_40_SlcPos_-33.707626341697.dcm')
-    src_dcm = pydicom.read_file(src_fn)
+    src_dcm = pydicom.dcmread(src_fn)
     src_dw = nb.nicom.dicomwrappers.wrapper_from_data(src_dcm)
     meta = {'EchoTime': 40}
     nw = dcmmeta.NiftiWrapper.from_dicom(src_dcm, meta)

--- a/test/test_dcmstack.py
+++ b/test/test_dcmstack.py
@@ -209,7 +209,7 @@ def test_image_collision():
                          'dcmstack',
                          '2D_16Echo_qT2',
                          'TE_20_SlcPos_-33.707626341697.dcm')
-    dcm = pydicom.read_file(dcm_path)
+    dcm = pydicom.dcmread(dcm_path)
     stack = dcmstack.DicomStack('EchoTime')
     stack.add_dcm(dcm)
     with pytest.raises(dcmstack.ImageCollisionError):
@@ -222,11 +222,11 @@ class TestIncongruentImage(object):
                              'dcmstack',
                              '2D_16Echo_qT2',
                              'TE_20_SlcPos_-33.707626341697.dcm')
-        self.dcm = pydicom.read_file(dcm_path)
+        self.dcm = pydicom.dcmread(dcm_path)
 
         self.stack = dcmstack.DicomStack()
         self.stack.add_dcm(self.dcm)
-        self.dcm = pydicom.read_file(dcm_path)
+        self.dcm = pydicom.dcmread(dcm_path)
 
     def _chk_raises(self):
         with pytest.raises(dcmstack.IncongruentImageError):
@@ -271,7 +271,7 @@ class TestInvalidStack(object):
                              'data',
                              'dcmstack',
                              '2D_16Echo_qT2')
-        self.inputs = [pydicom.read_file(path.join(data_dir, fn))
+        self.inputs = [pydicom.dcmread(path.join(data_dir, fn))
                        for fn in ('TE_20_SlcPos_-33.707626341697.dcm',
                                   'TE_20_SlcPos_-23.207628249046.dcm',
                                   'TE_40_SlcPos_-33.707626341697.dcm',
@@ -322,7 +322,7 @@ class TestGetShape(object):
                              'data',
                              'dcmstack',
                              '2D_16Echo_qT2')
-        self.inputs = [pydicom.read_file(path.join(data_dir, fn))
+        self.inputs = [pydicom.dcmread(path.join(data_dir, fn))
                        for fn in ('TE_40_SlcPos_-33.707626341697.dcm',
                                   'TE_40_SlcPos_-23.207628249046.dcm',
                                   'TE_60_SlcPos_-33.707626341697.dcm',
@@ -367,7 +367,7 @@ class TestGuessDim(object):
                              'data',
                              'dcmstack',
                              '2D_16Echo_qT2')
-        self.inputs = [pydicom.read_file(path.join(data_dir, fn))
+        self.inputs = [pydicom.dcmread(path.join(data_dir, fn))
                        for fn in ('TE_40_SlcPos_-33.707626341697.dcm',
                                   'TE_40_SlcPos_-23.207628249046.dcm',
                                   'TE_60_SlcPos_-33.707626341697.dcm',
@@ -417,7 +417,7 @@ class TestGetData(object):
                              'data',
                              'dcmstack',
                              '2D_16Echo_qT2')
-        self.inputs = [pydicom.read_file(path.join(data_dir, fn))
+        self.inputs = [pydicom.dcmread(path.join(data_dir, fn))
                        for fn in ('TE_40_SlcPos_-33.707626341697.dcm',
                                   'TE_40_SlcPos_-23.207628249046.dcm',
                                   'TE_60_SlcPos_-33.707626341697.dcm',
@@ -470,7 +470,7 @@ class TestGetAffine(object):
                              'data',
                              'dcmstack',
                              '2D_16Echo_qT2')
-        self.inputs = [pydicom.read_file(path.join(self.data_dir, fn))
+        self.inputs = [pydicom.dcmread(path.join(self.data_dir, fn))
                        for fn in ('TE_20_SlcPos_-33.707626341697.dcm',
                                   'TE_20_SlcPos_-23.207628249046.dcm'
                                  )
@@ -537,7 +537,7 @@ class TestToNifti(object):
                              'data',
                              'dcmstack',
                              '2D_16Echo_qT2')
-        self.inputs = [pydicom.read_file(path.join(self.data_dir, fn))
+        self.inputs = [pydicom.dcmread(path.join(self.data_dir, fn))
                        for fn in ('TE_20_SlcPos_-33.707626341697.dcm',
                                   'TE_20_SlcPos_-23.207628249046.dcm',
                                   'TE_40_SlcPos_-33.707626341697.dcm',
@@ -639,7 +639,7 @@ class TestParseAndGroup(object):
     def test_default(self):
         res = dcmstack.parse_and_group(self.in_paths)
         assert len(res) == 1
-        ds = pydicom.read_file(self.in_paths[0])
+        ds = pydicom.dcmread(self.in_paths[0])
         group_key = list(res.keys())[0]
         for attr_idx, attr in enumerate(dcmstack.default_group_keys):
             if attr in dcmstack.default_close_keys:
@@ -665,7 +665,7 @@ class TestParseAndStack(object):
     def test_default(self):
         res = dcmstack.parse_and_stack(self.in_paths)
         assert len(res) == 1
-        ds = pydicom.read_file(self.in_paths[0])
+        ds = pydicom.dcmread(self.in_paths[0])
         group_key = list(res.keys())[0]
         for attr_idx, attr in enumerate(dcmstack.default_group_keys):
             if attr in dcmstack.default_close_keys:

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -20,7 +20,7 @@ with warnings.catch_warnings():
 class TestCsa(object):
     def setup_method(self, method):
         data_fn = path.join(test_dir, 'data', 'extract', 'csa_test.dcm')
-        self.data = pydicom.read_file(data_fn)
+        self.data = pydicom.dcmread(data_fn)
 
     def teardown_method(self, method):
         del self.data
@@ -70,7 +70,7 @@ class TestCsa(object):
 class TestMetaExtractor(object):
     def setup_method(self, method):
         data_fn = path.join(test_dir, 'data', 'extract', 'csa_test.dcm')
-        self.data = pydicom.read_file(data_fn)
+        self.data = pydicom.dcmread(data_fn)
 
     def teardown_method(self,method):
         del self.data


### PR DESCRIPTION
read_file is removed in pydicom 3.0.0

Ideally release should follow asap.

CI might not run since was disabled by github due to inactivity awhile back